### PR TITLE
Upgrade the logic for parsing flags and add test.

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -89,7 +89,7 @@ func main() {
 		log.Fatal("-instances_metadata unsupported outside of Google Compute Engine")
 	}
 
-	instances, err := Check(*dir, *useFuse, strings.Split(*instances, ","), *instanceSrc)
+	cfgs, err := CreateInstanceConfigs(*dir, *useFuse, strings.Split(*instances, ","), *instanceSrc)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func main() {
 			}()
 		}
 
-		c, err := WatchInstances(*dir, instances, updates)
+		c, err := WatchInstances(*dir, cfgs, updates)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -157,11 +157,6 @@ func main() {
 
 	if *dir != "" {
 		log.Print("Socket prefix: " + *dir)
-	}
-	for _, cfg := range instances {
-		if strings.Contains(cfg.Network, "tcp") {
-			log.Printf("Listening for %v on %v", cfg.Instance, cfg.Address)
-		}
 	}
 
 	src, err := certs.NewCertSource(*host, client, *checkRegion)

--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestCheck(t *testing.T) {
+func TestCreateInstanceConfigs(t *testing.T) {
 	for _, v := range []struct {
 		desc string
 		//inputs
@@ -55,15 +55,15 @@ func TestCheck(t *testing.T) {
 			"", false, nil, "md", true,
 		},
 	} {
-		_, err := Check(v.dir, v.useFuse, v.instances, v.instancesSrc)
+		_, err := CreateInstanceConfigs(v.dir, v.useFuse, v.instances, v.instancesSrc)
 		if v.wantErr {
 			if err == nil {
-				t.Errorf("Check passed when %s, wanted error", v.desc)
+				t.Errorf("CreateInstanceConfigs passed when %s, wanted error", v.desc)
 			}
 			continue
 		}
 		if err != nil {
-			t.Errorf("Check gave error when %s: %v", v.desc, err)
+			t.Errorf("CreateInstanceConfigs gave error when %s: %v", v.desc, err)
 		}
 	}
 }

--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCheck(t *testing.T) {
+	for _, v := range []struct {
+		desc string
+		//inputs
+		dir          string
+		useFuse      bool
+		instances    []string
+		instancesSrc string
+
+		// We don't need to check the []instancesConfig return value, we already
+		// have a TestParseInstanceConfig.
+		wantErr bool
+	}{
+		{
+			"setting -fuse and -dir",
+			"dir", true, nil, "", false,
+		}, {
+			"setting -fuse",
+			"", true, nil, "", true,
+		}, {
+			"setting -fuse, -dir, and -instances",
+			"dir", true, []string{"x"}, "", true,
+		}, {
+			"setting -fuse, -dir, and -instances_metadata",
+			"dir", true, nil, "md", true,
+		}, {
+			"setting -dir and -instances (unix socket)",
+			"dir", false, []string{"x"}, "", false,
+		}, {
+			"Seting -instance (unix socket)",
+			"", false, []string{"x"}, "", true,
+		}, {
+			"setting -instance (tcp socket)",
+			"", false, []string{"x=tcp:1234"}, "", false,
+		}, {
+			"setting -instance (tcp socket) and -instances_metadata",
+			"", false, []string{"x=tcp:1234"}, "md", true,
+		}, {
+			"setting -dir, -instance (tcp socket), and -instances_metadata",
+			"dir", false, []string{"x=tcp:1234"}, "md", false,
+		}, {
+			"setting -dir, -instance (unix socket), and -instances_metadata",
+			"dir", false, []string{"x"}, "md", false,
+		}, {
+			"setting -dir and -instances_metadata",
+			"dir", false, nil, "md", false,
+		}, {
+			"setting -instances_metadata",
+			"", false, nil, "md", true,
+		},
+	} {
+		_, err := Check(v.dir, v.useFuse, v.instances, v.instancesSrc)
+		if v.wantErr {
+			if err == nil {
+				t.Errorf("Check passed when %s, wanted error", v.desc)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Check gave error when %s: %v", v.desc, err)
+		}
+	}
+}
+
+func TestParseInstanceConfig(t *testing.T) {
+	for _, v := range []struct {
+		// inputs
+		dir, instance string
+
+		wantCfg instanceConfig
+		wantErr bool
+	}{
+		{
+			"/x", "my-instance",
+			instanceConfig{"my-instance", "unix", "/x/my-instance"},
+			false,
+		}, {
+			"/x", "my-instance=tcp:1234",
+			instanceConfig{"my-instance", "tcp", "127.0.0.1:1234"},
+			false,
+		}, {
+			"/x", "my-instance=tcp:my-host:1111",
+			instanceConfig{"my-instance", "tcp", "my-host:1111"},
+			false,
+		}, {
+			"/x", "my-instance=",
+			instanceConfig{},
+			true,
+		}, {
+			"/x", "my-instance=cool network",
+			instanceConfig{},
+			true,
+		}, {
+			"/x", "my-instance=cool network:1234",
+			instanceConfig{},
+			true,
+		}, {
+			"/x", "my-instance=oh:so:many:colons",
+			instanceConfig{},
+			true,
+		},
+	} {
+		got, err := parseInstanceConfig(v.dir, v.instance)
+		if v.wantErr {
+			if err == nil {
+				t.Errorf("parseInstanceConfig(%s, %s) = %+v, wanted error", got)
+			}
+			continue
+		}
+		if got != v.wantCfg {
+			t.Errorf("parseInstanceConfig(%s, %s) = %+v, want %+v", v.dir, v.instance, got, v.wantCfg)
+		}
+	}
+}

--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -50,6 +50,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Supported returns true if the current system supports FUSE.
+// TODO: for OSX, check to see if OSX FUSE is installed.
+func Supported() bool {
+	return true
+}
+
 // NewConnSrc returns a source of new connections based on Lookups in the
 // provided mount directory. If there isn't a directory located at tmpdir one
 // is created. The second return parameter can be used to shutdown and release

--- a/proxy/fuse/fuse_windows.go
+++ b/proxy/fuse/fuse_windows.go
@@ -22,6 +22,10 @@ import (
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/proxy"
 )
 
+func Supported() bool {
+	return false
+}
+
 func NewConnSrc(mountdir, tmpdir string, connset *proxy.ConnSet) (<-chan proxy.Conn, io.Closer, error) {
 	return nil, nil, errors.New("fuse not supported on windows")
 }


### PR DESCRIPTION
Don't require -dir unless -fuse or -instances_metadata is used, or if
  -instances contains a unix socket.

Don't allow -instances_metadata unless running on GCE.

Give a nicer error if windows users try to use -instances.

Give a nicer message for systems which don't support FUSE and forgot to
  set -instances.