### PR TITLE
More log message cleanup:

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -180,7 +180,7 @@ var validNets = func() map[string]bool {
 		// Open any port to see if the net is valid.
 		x, err := net.Listen(n, addr+":")
 		if err != nil {
-			log.Printf("Protocol %v not supported: %v", n, err)
+			// Error is too verbose to be useful.
 			continue
 		}
 		x.Close()

--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -71,12 +71,12 @@ func NewConnSrc(mountdir, tmpdir string, connset *proxy.ConnSet) (<-chan proxy.C
 	if err := fuse.Unmount(mountdir); err != nil {
 		// The error is too verbose to be useful to print out
 	}
-	log.Printf("Mounting %q...", mountdir)
+	log.Printf("Mounting %v...", mountdir)
 	c, err := fuse.Mount(mountdir, fuse.AllowOther())
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot mount %q: %v", mountdir, err)
 	}
-	log.Printf("Mounted %q", mountdir)
+	log.Printf("Mounted %v", mountdir)
 
 	if connset == nil {
 		// Make a dummy one.
@@ -111,6 +111,7 @@ func NewConnSrc(mountdir, tmpdir string, connset *proxy.ConnSet) (<-chan proxy.C
 		if err := root.Close(); err != nil {
 			log.Printf("root.Close() error: %v", err)
 		}
+		log.Printf("FUSE exited")
 	}()
 
 	return conns, root, nil


### PR DESCRIPTION
* Explicit message when a GCE VM doesn't have a service account attached.
* Message when FUSE exits.
* Don't print out a message when an ip version (ipv4/ipv6) isn't supported

Finishes up https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/11