### PR TITLE
Correcting scope in permission check

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ are not compatible with the `-fuse` flag.
 
 By default, the proxy will authenticate under the default service account of the
 Compute Engine VM it is running on. Therefore, the VM must have at least the
-sql-admin API scope and the associated project must have the SQL Admin API
+sqlservice.admin API scope ("https://www.googleapis.com/auth/sqlservice.admin") 
+and the associated project must have the SQL Admin API
 enabled.  The default service account must also have at least WRITER/EDITOR
 priviledges to any projects of target SQL instances.
 

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -186,7 +186,7 @@ func checkFlags(onGCE bool) error {
 
 	ok := false
 	for _, sc := range scopes {
-		if sc == "https://www.googleapis.com/auth/sqladmin" || sc == "https://www.googleapis.com/auth/cloud-platform" {
+		if sc == sqlScope || sc == "https://www.googleapis.com/auth/cloud-platform" {
 			ok = true
 			break
 		}


### PR DESCRIPTION
Replacing https://www.googleapis.com/auth/sqladmin with https://www.googleapis.com/auth/sqlservice.admin 

Fixing #20