### PR TITLE
Respect credential_file and token args on GCE

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -176,6 +176,11 @@ func checkFlags(onGCE bool) error {
 		}
 		return nil
 	}
+
+	if *token != "" || *tokenFile != "" || os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") != "" {
+		return nil
+	}
+
 	scopes, err := metadata.Scopes("default")
 	if err != nil {
 		if _, ok := err.(metadata.NotDefinedError); ok {


### PR DESCRIPTION
Skip permissions check for GCE VM service account when a credential_file
or token were passed as arguments. Fixes #26

This was the least invasive change I could make to address this. The content check on tokenFile and token is now done here and in `authenticatedClient(ctx context.Context)` but I'm not sure what the best way to refactor this would be.

I tested on a default GCE instance and got the expected error when passing no credential file and successfully connected when passing the file.