### PR TITLE
adding port 0 call to validNets listen test

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -178,7 +178,7 @@ var validNets = func() map[string]bool {
 			panic(fmt.Sprintf("no loopback address found for %v", n))
 		}
 		// Open any port to see if the net is valid.
-		x, err := net.Listen(n, addr+":")
+		x, err := net.Listen(n, addr+":0")
 		if err != nil {
 			// Error is too verbose to be useful.
 			continue


### PR DESCRIPTION
Changing the listen call to use port 0 to grab an available port, the current code doesn't work on alpine linux in a container. This small change fixes it and I don't see a reason it would break other use cases assuming the Go source code is correct:
> If laddr has a port of 0, ListenTCP will choose an available port.

Example of this breaking:

>cloud_sql_proxy -dir=/cloudsql -instances=PROJECT:us-central1:INSTANCE=tcp:3306 -credential_file=/account.json
>2016/04/26 20:20:56 errors parsing config:
	invalid "PROJECT:us-central1:INSTANCE=tcp:3306": unrecognized network tcp