### PR TITLE
Fix undefined metadata due to changes to the Cloud packages

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -39,11 +39,11 @@ import (
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/fuse"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/proxy"
 
+	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	goauth "golang.org/x/oauth2/google"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
-	"google.golang.org/cloud/compute/metadata"
 )
 
 var (


### PR DESCRIPTION
Will build fail when running 

```
go get github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy
```

due to the changes to the Cloud packages, see the details in
https://godoc.org/google.golang.org/cloud/compute/metadata