### PR TITLE
Fix kubernetes usage example: missing region part. No environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ kubectl create -f secret.json
       mountPath: /secret/
     - name: ssl-certs
       mountPath: /etc/ssl/certs
-    command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-credential_file=/secret/file.json", "-instances=$MYPROJECT:MYINSTANCE"]
+    command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-credential_file=/secret/file.json", "-instances=MYPROJECT:MYREGION:MYINSTANCE"]
 ```
 Note that we pass the path to the secret file in the command line arguments to the proxy.
 We also pass the project and Cloud SQL instance name we want to connect to using the "--instances" flag.


### PR DESCRIPTION
The region part of the fully qualified instance parameter was missing: `project:region:name`.

Also, I removed the $ sign to avoid letting us think we can evaluate environment variable specified in command directly.
A workaround would be to wrap the command into `sh -c` but this docker image does not include any shell (`FROM scratch`).
cf. https://github.com/kubernetes/kubernetes/issues/1309#issuecomment-55524273