### PR TITLE
Bug fix: Create the directory first and then check using os.IsNotExist

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -241,9 +241,6 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 		}
 		if strings.HasPrefix(strings.ToLower(in.DatabaseVersion), "postgres") {
 			path := filepath.Join(dir, instance)
-			if _, err := os.Stat(path); !os.IsNotExist(err) {
-				return instanceConfig{}, err
-			}
 			if err := os.MkdirAll(path, 0755); err != nil {
 				return instanceConfig{}, err
 			}


### PR DESCRIPTION
!os.IsNotExist(err) returns true even when err == nil.