### PR TITLE
Add Helm chart (#61)

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+name: cloudsql-proxy
+description: Deploys a Google Cloud SQL proxy as a Kubernetes service
+version: 0.1.0
+maintainers:
+  - name: Tan Jay Jun
+    email: tan@jayjun.com

--- a/helm/sample-values.yaml
+++ b/helm/sample-values.yaml
@@ -1,0 +1,19 @@
+# Default values for cloud-sql-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+app:
+  namespace: my-namespace
+database:
+  project: project-name
+  region: region-name
+  instance: database-name
+  username: username
+  password: password
+image:
+  repository: gcr.io/cloudsql-docker/gce-proxy
+  tag: 1.06
+service:
+  name: cloudsql-proxy
+  externalPort: 3306
+  internalPort: 3306

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                  "-instances={{ .Values.database.project }}:{{ .Values.database.region }}:{{ .Values.database.instance }}=tcp:0.0.0.0:{{ .Values.service.internalPort }}",
+                  "-credential_file=/secrets/cloudsql/credentials.json"]
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        volumeMounts:
+        - name: cloudsql-oauth-credentials
+          mountPath: /secrets/cloudsql
+          readOnly: true
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+        - name: cloudsql
+          mountPath: /cloudsql

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ .Chart.Name }}


### PR DESCRIPTION
This chart creates a standalone Kubernetes pod and service hosting Cloud SQL proxy. In its own namespace, if desired.

It exposes the proxy to the whole cluster by starting it with `tcp:0.0.0.0:3306` set, instead of `tcp:3306` which is only suitable for the "sidecar" pattern. This is significantly different from all the other methods recommended in the guide, and a potential security risk.

Also, I'm not sure if this repo is the right place to host this.