### PR TITLE
Fix the issue on project ids which prefixed by organization

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -235,7 +235,7 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 		ret.Instance = instance
 		// Default to unix socket.
 		ret.Network = "unix"
-		spl := strings.SplitN(instance, ":", 3)
+		spl := strings.SplitN(instance, ":", 4)
 
 		var proj, name string
 		if len(spl) < 2 {
@@ -245,8 +245,12 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 			// fail later in the code if this isn't allowed, so just assume it's
 			// allowed until we actually need the region in this API call.
 			proj, name = spl[0], spl[1]
-		} else { // if len(spl) == 3
+		} else if len(spl) == 3 {
 			proj, name = spl[0], spl[2]
+		} else {
+			// Some project ids include organization prefix like google.com:Project_ID
+			// Merging first 2 parts again with colon to revert it back to original project id
+			proj, name = spl[0] + ":" + spl[1], spl[3]
 		}
 		in, err := sql.Instances.Get(proj, name).Do()
 		if err != nil {


### PR DESCRIPTION
Some cloud project ids have organization as prefix, separated with colon. It makes problem on parsing configuration that passes by -instances parameter. 

The observer error is :
 errors parsing config:
	googleapi: Error 403: The client is not authorized to make this request., notAuthorized

This fix handles this scenario and merge organization to project id again.