### PR TITLE
Use alpine docker base image to get certificates

### DIFF
--- a/Kubernetes.md
+++ b/Kubernetes.md
@@ -23,9 +23,6 @@ In order to set-up the Cloud SQL you will need,
   [the documentation](https://cloud.google.com/docs/authentication#developer_workflow)
   to get the json credential file.
 
-- You need CA Certificates. You can download it from [CURL](https://curl.haxx.se/ca/cacert.pem).
-  We will assume that the file is located as `$HOME/cacert.pem`.
-
 - Your `$HOME/.kube/config` points to your cluster and the namespace you
   want to use.
 
@@ -38,20 +35,14 @@ node. We will use [Kubernetes DNS
 service](http://kubernetes.io/docs/admin/dns/) to connect to the proxy
 seamlessly.
 
-Setting-up the credentials and certificates
--------------------------------------------
+Setting-up the credentials
+--------------------------
 
 We need to create a secret to store the credentials that the Cloud Proxy
 needs to connect to the project database instances:
 
 ```
 kubectl create secret generic service-account-token --from-file=credentials.json=$HOME/credentials.json
-```
-
-You will also need to install CA Certificates. We will set-up the file as a configmap:
-
-```
-kubectl create configmap ca-certificates --from-file=ca-certificates.crt=$HOME/cacert.pem
 ```
 
 Creating the Cloud SLQ Proxy deployment
@@ -92,17 +83,12 @@ spec:
           name: cloudsql
         - mountPath: /credentials
           name: service-account-token
-        - mountPath: /etc/ssl/certs
-          name: ca-certificates
       volumes:
       - name: cloudsql
         emptyDir:
       - name: service-account-token
         secret:
           secretName: service-account-token
-      - name: ca-certificates
-        configMap:
-          name: ca-certificates
 ```
 
 And then, create the deployment:

--- a/README.md
+++ b/README.md
@@ -108,20 +108,13 @@ $ kubectl create -f secret.yaml
       secretName: sqlcreds
 ```
 
-* You'll also need to create a `hostPath` volume allowing the SQL proxy to read SSL certificates:
-```
-- name: ssl-certs
-  hostPath:
-    path: /etc/ssl/certs
-```
-
 * Create an emptydir volume named `cloudsql` for the SQL proxy to place it's socket:
 ```
   - name: cloudsql
     emptyDir:
 ```
 
-* Add the SQL proxy container to your pod, and mount the `sqlcreds` and 'ssl-certs' volumes, making sure to pass the correct instance and project.
+* Add the SQL proxy container to your pod, and mount the `sqlcreds` volume, making sure to pass the correct instance and project.
 ```
   - image: gcr.io/cloudsql-docker/gce-proxy:1.06
     volumeMounts:
@@ -129,8 +122,6 @@ $ kubectl create -f secret.yaml
       mountPath: /cloudsql
     - name: secret-volume
       mountPath: /secret/
-    - name: ssl-certs
-      mountPath: /etc/ssl/certs
     command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-credential_file=/secret/file.json", "-instances=MYPROJECT:MYREGION:MYINSTANCE"]
 ```
 Note that we pass the path to the secret file in the command line arguments to the proxy.

--- a/cmd/cloud_sql_proxy/build.sh
+++ b/cmd/cloud_sql_proxy/build.sh
@@ -93,7 +93,9 @@ case $1 in
   build
 
   cat >Dockerfile <<EOF
-FROM scratch
+FROM alpine:3.5
+
+RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 COPY cloud_sql_proxy.docker /cloud_sql_proxy
 EOF


### PR DESCRIPTION
Currently, one has to map a volume with certificates to the image.

We could simply fix that by using alpine and install certificates
directly in the image.