### PR TITLE
Add Quiet Flag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@
 
 # Please keep the list sorted.
 
+Mykola Smith <mykolasmith@gmail.com>
 Frank van Rest <frankvanrest@gmail.com>
 Kevin Malachowski <chowski@google.com>
 

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -48,6 +48,7 @@ import (
 
 var (
 	version = flag.Bool("version", false, "Print the version of the proxy and exit")
+	quiet   = flag.Bool("quiet", false, "Disable log messages")
 
 	checkRegion = flag.Bool("check_region", false, `If specified, the 'region' portion of the connection string is required for
 UNIX socket-based connections.`)
@@ -102,6 +103,11 @@ Authorization:
     flag or set the GOOGLE_APPLICATION_CREDENTIALS environment variable. This
     will override gcloud or GCE credentials (if they exist).
 
+General:
+	-quiet
+		Disable log messages (e.g. when new connections are established).
+		WARNING: this option disables ALL logging output (including connection
+		errors), which will likely make debugging difficult.
 
 Connection:
   -instances
@@ -331,6 +337,12 @@ func main() {
 	if *version {
 		fmt.Println("Cloud SQL Proxy:", versionString)
 		return
+	}
+
+	if *quiet {
+		log.Println("Cloud SQL Proxy logging has been disabled by the -quiet flag. All messages (including errors) will be suppressed.")
+		log.SetFlags(0)
+		log.SetOutput(ioutil.Discard)
 	}
 
 	instList := stringList(*instances)


### PR DESCRIPTION
Hello,

This pull requests adds a `-quiet` flag. I am using `cloud_sql_proxy` in production on Google Container Engine, [per these instructions](https://cloud.google.com/sql/docs/postgres/connect-container-engine), and the constant "Connection established" logging pollutes our log streams (and will eventually incur additional costs to Stackdriver Logging). Please consider merging this PR so that we may silence logging.

Thanks!