### PR TITLE
Add -verbose flag to allow users to turn off verbose output

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -35,6 +35,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/certs"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/fuse"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/proxy"
@@ -51,6 +52,7 @@ var (
 
 	checkRegion = flag.Bool("check_region", false, `If specified, the 'region' portion of the connection string is required for
 UNIX socket-based connections.`)
+	verbose = flag.Bool("verbose", true, "If false, verbose output such as information about when connections are created/closed without error are suppressed")
 
 	// Settings for how to choose which instance to connect to.
 	dir      = flag.String("dir", "", "Directory to use for placing UNIX sockets representing database instances")
@@ -214,7 +216,7 @@ func authenticatedClient(ctx context.Context) (*http.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid json file %q: %v", f, err)
 		}
-		log.Printf("using credential file for authentication; email=%s", cfg.Email)
+		logging.Infof("using credential file for authentication; email=%s", cfg.Email)
 		return cfg.Client(ctx), nil
 	} else if tok := *token; tok != "" {
 		src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tok})
@@ -259,7 +261,7 @@ func listInstances(ctx context.Context, cl *http.Client, projects []string) ([]s
 				return nil
 			})
 			if err != nil {
-				log.Printf("Error listing instances in %v: %v", proj, err)
+				logging.Errorf("Error listing instances in %v: %v", proj, err)
 			}
 			wg.Done()
 		}()
@@ -288,7 +290,7 @@ func gcloudProject() []string {
 			// gcloud not installed; ignore the error
 			return nil
 		}
-		log.Printf("Error detecting gcloud project: %v", err)
+		logging.Errorf("Error detecting gcloud project: %v", err)
 		return nil
 	}
 
@@ -299,12 +301,12 @@ func gcloudProject() []string {
 	}
 
 	if err := json.Unmarshal(buf.Bytes(), &data); err != nil {
-		log.Printf("Failed to unmarshal bytes from gcloud: %v", err)
-		log.Printf("   gcloud returned:\n%s", buf)
+		logging.Errorf("Failed to unmarshal bytes from gcloud: %v", err)
+		logging.Errorf("   gcloud returned:\n%s", buf)
 		return nil
 	}
 
-	log.Printf("Using gcloud's active project: %v", data.Core.Project)
+	logging.Infof("Using gcloud's active project: %v", data.Core.Project)
 	return []string{data.Core.Project}
 }
 
@@ -331,6 +333,10 @@ func main() {
 	if *version {
 		fmt.Println("Cloud SQL Proxy:", versionString)
 		return
+	}
+
+	if *verbose {
+		logging.Verbosef = func(string, ...interface{}) {}
 	}
 
 	instList := stringList(*instances)
@@ -386,7 +392,7 @@ func main() {
 						return nil
 					})
 					if err != nil {
-						log.Print(err)
+						logging.Errorf("Error on receiving new instances from metadata: %v", err)
 					}
 					time.Sleep(5 * time.Second)
 				}
@@ -400,7 +406,7 @@ func main() {
 		connSrc = c
 	}
 
-	log.Print("Ready for new connections")
+	logging.Infof("Ready for new connections")
 
 	(&proxy.Client{
 		Port:  port,

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -49,11 +49,11 @@ import (
 
 var (
 	version = flag.Bool("version", false, "Print the version of the proxy and exit")
+	verbose = flag.Bool("verbose", true, "If false, verbose output such as information about when connections are created/closed without error are suppressed")
 	quiet   = flag.Bool("quiet", false, "Disable log messages")
 
 	checkRegion = flag.Bool("check_region", false, `If specified, the 'region' portion of the connection string is required for
 UNIX socket-based connections.`)
-	verbose = flag.Bool("verbose", true, "If false, verbose output such as information about when connections are created/closed without error are suppressed")
 
 	// Settings for how to choose which instance to connect to.
 	dir      = flag.String("dir", "", "Directory to use for placing UNIX sockets representing database instances")

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,31 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logging contains helpers to support log messages. If you are using
+// the Cloud SQL Proxy as a Go library, you can override these variables to
+// control where log messages end up.
+package logging
+
+import "log"
+
+// Verbosef is called to write verbose logs, such as when a new connection is
+// established correctly.
+var Verbosef = log.Printf
+
+// Infof is called to write informational logs, such as when startup has
+// completed.
+var Infof = log.Printf
+
+// Errorf is called to write an error log, such as when a new connection fails.
+var Errorf = log.Printf

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -23,12 +23,12 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	mrand "math/rand"
 	"net/http"
 	"time"
 
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/util"
 	"google.golang.org/api/googleapi"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
@@ -96,7 +96,7 @@ func backoffAPIRetry(desc, instance string, do func() error) error {
 		// sleep = baseBackoff * backoffMult^(retries + randomFactor)
 		exp := float64(i+1) + mrand.Float64()
 		sleep := time.Duration(baseBackoff * math.Pow(backoffMult, exp))
-		log.Printf("Error in %s %s: %v; retrying in %v", desc, instance, err, sleep)
+		logging.Errorf("Error in %s %s: %v; retrying in %v", desc, instance, err, sleep)
 		time.Sleep(sleep)
 	}
 	return err
@@ -172,8 +172,8 @@ func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr
 		if s.checkRegion {
 			return nil, "", "", err
 		}
-		log.Print(err)
-		log.Print("WARNING: specifying the correct region in an instance string will become required in a future version!")
+		logging.Errorf("%v", err)
+		logging.Errorf("WARNING: specifying the correct region in an instance string will become required in a future version!")
 	}
 	if len(data.IpAddresses) == 0 || data.IpAddresses[0].IpAddress == "" {
 		return nil, "", "", fmt.Errorf("no IP address found for %v", instance)


### PR DESCRIPTION
The flag defaults to true to keep old functionality (and to ease debugging when first setting it up), but people running the proxy in a server environment will likely want to turn off verbose output.

At some point we could consider setting the default to false.

Addresses #44 along with #100 