### PR TITLE
Add -max_connections flag to put a hard limit on the number of connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/cloud_sql_proxy

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -412,7 +412,7 @@ func main() {
 	}
 	instList = append(instList, ins...)
 
-	cfgs, err := CreateInstanceConfigs(*dir, *useFuse, instList, *instanceSrc, *maxConnections, client)
+	cfgs, err := CreateInstanceConfigs(*dir, *useFuse, instList, *instanceSrc, client)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -74,7 +74,7 @@ directory at 'dir' must be empty before this program is started.`)
 can be removed automatically by this program.`)
 
 	// Settings for limits
-	maxConnections = flag.Int("max_connections", 0, `If provided, the maximum number of connections to establish before refusing new connections. Defaults to 0 (no limit)`)
+	maxConnections = flag.Uint64("max_connections", 0, `If provided, the maximum number of connections to establish before refusing new connections. Defaults to 0 (no limit)`)
 
 	// Settings for authentication.
 	token     = flag.String("token", "", "When set, the proxy uses this Bearer token for authorization.")
@@ -464,7 +464,7 @@ func main() {
 	logging.Infof("Ready for new connections")
 
 	(&proxy.Client{
-		Port: port,
+		Port:           port,
 		MaxConnections: *maxConnections,
 		Certs: certs.NewCertSourceOpts(client, certs.RemoteOpts{
 			APIBasePath:  host,

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -73,6 +73,9 @@ directory at 'dir' must be empty before this program is started.`)
 	fuseTmp = flag.String("fuse_tmp", defaultTmp, `Used as a temporary directory if -fuse is set. Note that files in this directory
 can be removed automatically by this program.`)
 
+	// Settings for limits
+	maxConnections = flag.Int("max_connections", 0, `If provided, the maximum number of connections to establish before refusing new connections. Defaults to 0 (no limit)`)
+
 	// Settings for authentication.
 	token     = flag.String("token", "", "When set, the proxy uses this Bearer token for authorization.")
 	tokenFile = flag.String("credential_file", "", `If provided, this json file will be used to retrieve Service Account credentials.
@@ -409,7 +412,7 @@ func main() {
 	}
 	instList = append(instList, ins...)
 
-	cfgs, err := CreateInstanceConfigs(*dir, *useFuse, instList, *instanceSrc, client)
+	cfgs, err := CreateInstanceConfigs(*dir, *useFuse, instList, *instanceSrc, *maxConnections, client)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -462,6 +465,7 @@ func main() {
 
 	(&proxy.Client{
 		Port: port,
+		MaxConnections: *maxConnections,
 		Certs: certs.NewCertSourceOpts(client, certs.RemoteOpts{
 			APIBasePath:  host,
 			IgnoreRegion: !*checkRegion,

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -292,7 +292,7 @@ func parseInstanceConfigs(dir string, instances []string, cl *http.Client) ([]in
 // CreateInstanceConfigs verifies that the parameters passed to it are valid
 // for the proxy for the platform and system and then returns a slice of valid
 // instanceConfig.
-func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instancesSrc string, cl *http.Client) ([]instanceConfig, error) {
+func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instancesSrc string, maxConnections int, cl *http.Client) ([]instanceConfig, error) {
 	if useFuse && !fuse.Supported() {
 		return nil, errors.New("FUSE not supported on this system")
 	}

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -292,7 +292,7 @@ func parseInstanceConfigs(dir string, instances []string, cl *http.Client) ([]in
 // CreateInstanceConfigs verifies that the parameters passed to it are valid
 // for the proxy for the platform and system and then returns a slice of valid
 // instanceConfig.
-func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instancesSrc string, maxConnections uint64, cl *http.Client) ([]instanceConfig, error) {
+func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instancesSrc string, cl *http.Client) ([]instanceConfig, error) {
 	if useFuse && !fuse.Supported() {
 		return nil, errors.New("FUSE not supported on this system")
 	}

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -292,7 +292,7 @@ func parseInstanceConfigs(dir string, instances []string, cl *http.Client) ([]in
 // CreateInstanceConfigs verifies that the parameters passed to it are valid
 // for the proxy for the platform and system and then returns a slice of valid
 // instanceConfig.
-func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instancesSrc string, maxConnections int, cl *http.Client) ([]instanceConfig, error) {
+func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instancesSrc string, maxConnections uint64, cl *http.Client) ([]instanceConfig, error) {
 	if useFuse && !fuse.Supported() {
 		return nil, errors.New("FUSE not supported on this system")
 	}

--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -34,11 +34,10 @@ func TestCreateInstanceConfigs(t *testing.T) {
 	for _, v := range []struct {
 		desc string
 		//inputs
-		dir            string
-		useFuse        bool
-		instances      []string
-		instancesSrc   string
-		maxConnections uint64
+		dir          string
+		useFuse      bool
+		instances    []string
+		instancesSrc string
 
 		// We don't need to check the []instancesConfig return value, we already
 		// have a TestParseInstanceConfig.
@@ -46,46 +45,43 @@ func TestCreateInstanceConfigs(t *testing.T) {
 	}{
 		{
 			"setting -fuse and -dir",
-			"dir", true, nil, "", 0, false,
+			"dir", true, nil, "", false,
 		}, {
 			"setting -fuse",
-			"", true, nil, "", 0, true,
+			"", true, nil, "", true,
 		}, {
 			"setting -fuse, -dir, and -instances",
-			"dir", true, []string{"proj:reg:x"}, "", 0, true,
+			"dir", true, []string{"proj:reg:x"}, "", true,
 		}, {
 			"setting -fuse, -dir, and -instances_metadata",
-			"dir", true, nil, "md", 0, true,
+			"dir", true, nil, "md", true,
 		}, {
 			"setting -dir and -instances (unix socket)",
-			"dir", false, []string{"proj:reg:x"}, "", 0, false,
+			"dir", false, []string{"proj:reg:x"}, "", false,
 		}, {
-			"setting -instance (unix socket)",
-			"", false, []string{"proj:reg:x"}, "", 0, true,
+			"Seting -instance (unix socket)",
+			"", false, []string{"proj:reg:x"}, "", true,
 		}, {
 			"setting -instance (tcp socket)",
-			"", false, []string{"proj:reg:x=tcp:1234"}, "", 0, false,
+			"", false, []string{"proj:reg:x=tcp:1234"}, "", false,
 		}, {
 			"setting -instance (tcp socket) and -instances_metadata",
-			"", false, []string{"proj:reg:x=tcp:1234"}, "md", 0, true,
+			"", false, []string{"proj:reg:x=tcp:1234"}, "md", true,
 		}, {
 			"setting -dir, -instance (tcp socket), and -instances_metadata",
-			"dir", false, []string{"proj:reg:x=tcp:1234"}, "md", 0, false,
+			"dir", false, []string{"proj:reg:x=tcp:1234"}, "md", false,
 		}, {
 			"setting -dir, -instance (unix socket), and -instances_metadata",
-			"dir", false, []string{"proj:reg:x"}, "md", 0, false,
+			"dir", false, []string{"proj:reg:x"}, "md", false,
 		}, {
 			"setting -dir and -instances_metadata",
-			"dir", false, nil, "md", 0, false,
+			"dir", false, nil, "md", false,
 		}, {
 			"setting -instances_metadata",
-			"", false, nil, "md", 0, true,
-		}, {
-			"setting -max_connections",
-			"dir", true, nil, "", 10, false,
+			"", false, nil, "md", true,
 		},
 	} {
-		_, err := CreateInstanceConfigs(v.dir, v.useFuse, v.instances, v.instancesSrc, v.maxConnections, mockClient)
+		_, err := CreateInstanceConfigs(v.dir, v.useFuse, v.instances, v.instancesSrc, mockClient)
 		if v.wantErr {
 			if err == nil {
 				t.Errorf("CreateInstanceConfigs passed when %s, wanted error", v.desc)

--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -34,10 +34,11 @@ func TestCreateInstanceConfigs(t *testing.T) {
 	for _, v := range []struct {
 		desc string
 		//inputs
-		dir          string
-		useFuse      bool
-		instances    []string
-		instancesSrc string
+		dir            string
+		useFuse        bool
+		instances      []string
+		instancesSrc   string
+		maxConnections int
 
 		// We don't need to check the []instancesConfig return value, we already
 		// have a TestParseInstanceConfig.
@@ -45,43 +46,46 @@ func TestCreateInstanceConfigs(t *testing.T) {
 	}{
 		{
 			"setting -fuse and -dir",
-			"dir", true, nil, "", false,
+			"dir", true, nil, "", 0, false,
 		}, {
 			"setting -fuse",
-			"", true, nil, "", true,
+			"", true, nil, "", 0, true,
 		}, {
 			"setting -fuse, -dir, and -instances",
-			"dir", true, []string{"proj:reg:x"}, "", true,
+			"dir", true, []string{"proj:reg:x"}, "", 0, true,
 		}, {
 			"setting -fuse, -dir, and -instances_metadata",
-			"dir", true, nil, "md", true,
+			"dir", true, nil, "md", 0, true,
 		}, {
 			"setting -dir and -instances (unix socket)",
-			"dir", false, []string{"proj:reg:x"}, "", false,
+			"dir", false, []string{"proj:reg:x"}, "", 0, false,
 		}, {
-			"Seting -instance (unix socket)",
-			"", false, []string{"proj:reg:x"}, "", true,
+			"setting -instance (unix socket)",
+			"", false, []string{"proj:reg:x"}, "", 0, true,
 		}, {
 			"setting -instance (tcp socket)",
-			"", false, []string{"proj:reg:x=tcp:1234"}, "", false,
+			"", false, []string{"proj:reg:x=tcp:1234"}, "", 0, false,
 		}, {
 			"setting -instance (tcp socket) and -instances_metadata",
-			"", false, []string{"proj:reg:x=tcp:1234"}, "md", true,
+			"", false, []string{"proj:reg:x=tcp:1234"}, "md", 0, true,
 		}, {
 			"setting -dir, -instance (tcp socket), and -instances_metadata",
-			"dir", false, []string{"proj:reg:x=tcp:1234"}, "md", false,
+			"dir", false, []string{"proj:reg:x=tcp:1234"}, "md", 0, false,
 		}, {
 			"setting -dir, -instance (unix socket), and -instances_metadata",
-			"dir", false, []string{"proj:reg:x"}, "md", false,
+			"dir", false, []string{"proj:reg:x"}, "md", 0, false,
 		}, {
 			"setting -dir and -instances_metadata",
-			"dir", false, nil, "md", false,
+			"dir", false, nil, "md", 0, false,
 		}, {
 			"setting -instances_metadata",
-			"", false, nil, "md", true,
+			"", false, nil, "md", 0, true,
+		}, {
+			"setting -max_connections",
+			"dir", true, nil, "", 10, false,
 		},
 	} {
-		_, err := CreateInstanceConfigs(v.dir, v.useFuse, v.instances, v.instancesSrc, mockClient)
+		_, err := CreateInstanceConfigs(v.dir, v.useFuse, v.instances, v.instancesSrc, v.maxConnections, mockClient)
 		if v.wantErr {
 			if err == nil {
 				t.Errorf("CreateInstanceConfigs passed when %s, wanted error", v.desc)

--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -38,7 +38,7 @@ func TestCreateInstanceConfigs(t *testing.T) {
 		useFuse        bool
 		instances      []string
 		instancesSrc   string
-		maxConnections int
+		maxConnections uint64
 
 		// We don't need to check the []instancesConfig return value, we already
 		// have a TestParseInstanceConfig.

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -120,7 +120,8 @@ func (c *Client) handleConn(conn Conn) {
 
 		if active > c.MaxConnections {
 			conn.Conn.Close()
-			logging.Errorf("Too many open connections (max %d)", c.MaxConnections)
+			logging.Errorf("too many open connections (max %d)", c.MaxConnections)
+			return
 		}
 	}
 

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -119,8 +119,8 @@ func (c *Client) handleConn(conn Conn) {
 		defer atomic.AddUint64(&c.ConnectionsCounter, ^uint64(0))
 
 		if active > c.MaxConnections {
-			conn.Conn.Close()
 			logging.Errorf("too many open connections (max %d)", c.MaxConnections)
+			conn.Conn.Close()
 			return
 		}
 	}

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -87,7 +87,7 @@ type Client struct {
 	MaxConnections uint64
 
 	// ConnectionsCounter is used to enforce the optional maxConnections limit
-	ConnectionsCounter  uint64
+	ConnectionsCounter uint64
 }
 
 type cacheEntry struct {

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -87,7 +87,8 @@ type Client struct {
 	MaxConnections uint64
 
 	// ConnectionsCounter is used to enforce the optional maxConnections limit
-	ConnectionsCounter uint64
+	ConnectionsCounter  uint64
+	ConnectionsCounterL sync.RWMutex
 }
 
 type cacheEntry struct {

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -88,7 +88,6 @@ type Client struct {
 
 	// ConnectionsCounter is used to enforce the optional maxConnections limit
 	ConnectionsCounter  uint64
-	ConnectionsCounterL sync.RWMutex
 }
 
 type cacheEntry struct {

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -146,13 +146,17 @@ func TestMaximumConnectionsCount(t *testing.T) {
 		MaxConnections: maxConnections,
 	}
 
-	var wg sync.WaitGroup
-
+	// Build certSource.values before creating goroutines to avoid concurrent map read and map write
+	instanceNames := make([]string, numConnections)
 	for i := 0; i < numConnections; i++ {
 		// Vary instance name to bypass config cache and avoid second call to Client.tryConnect() in Client.Dial()
 		instanceName := fmt.Sprintf("%s-%d", instance, i)
 		certSource.values[instanceName] = b
+		instanceNames[i] = instanceName
+	}
 
+	var wg sync.WaitGroup
+	for _, instanceName := range instanceNames {
 		wg.Add(1)
 		go func(instanceName string) {
 			defer wg.Done()

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -175,7 +174,7 @@ func TestMaximumConnectionsCount(t *testing.T) {
 	case dials > maxConnections:
 		t.Errorf("client should have refused to dial new connection on %dth attempt when the maximum of %d connections was reached (%d dials)", numConnections, maxConnections, dials)
 	case dials == maxConnections:
-		logging.Infof("client has correctly refused to dial new connection on %dth attempt when the maximum of %d connections was reached (%d dials)\n", numConnections, maxConnections, dials)
+		t.Logf("client has correctly refused to dial new connection on %dth attempt when the maximum of %d connections was reached (%d dials)\n", numConnections, maxConnections, dials)
 	case dials < maxConnections:
 		t.Errorf("client should have dialed exactly the maximum of %d connections (%d connections, %d dials)", maxConnections, numConnections, dials)
 	}

--- a/proxy/proxy/common_test.go
+++ b/proxy/proxy/common_test.go
@@ -26,6 +26,10 @@ var c1, c2, c3 = &dummyConn{}, &dummyConn{}, &dummyConn{}
 
 type dummyConn struct{ net.Conn }
 
+func (c dummyConn) Close() error {
+	return nil
+}
+
 func TestConnSetAdd(t *testing.T) {
 	s := NewConnSet()
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -1,0 +1,391 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Common test setup code
+package tests
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/proxy"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	compute "google.golang.org/api/compute/v1"
+	"strings"
+)
+
+var (
+	project      = flag.String("project", "", "Project to create the GCE test VM in")
+	zone         = flag.String("zone", "us-central1-f", "Zone in which to create the VM")
+	osImage      = flag.String("os", defaultOS, "OS image to use when creating a VM")
+	vmName       = flag.String("vm_name", "proxy-test-gce", "Name of VM to create")
+	databaseName = flag.String("db_name", "", "Fully-qualified Cloud SQL Instance (in the form of 'project:region:instance-name')")
+)
+
+const (
+	defaultOS       = "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160329"
+	testTimeout     = 3 * time.Minute
+	buildShLocation = "cmd/cloud_sql_proxy/build.sh"
+)
+
+func setupGCEProxy(t *testing.T, proxyArgs []string) (error, *ssh.Client) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	proxyBinary, err := compileProxy()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Built new cloud_sql_proxy binary")
+	defer os.Remove(proxyBinary)
+
+	cl, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ssh, err := newOrReuseVM(t.Logf, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("SSH to %s:%s succeeded", *project, *vmName)
+
+	log.Printf("apt-get update...")
+	var sout, serr bytes.Buffer
+	if err := sshRun(ssh, "sudo apt-get update", nil, &sout, &serr); err != nil {
+		t.Fatal("Failed 'sudo apt-get update' on remote machine: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+	}
+	log.Printf("Install mysql client...")
+	if err := sshRun(ssh, "sudo apt-get install -y mysql-client", nil, &sout, &serr); err != nil {
+		t.Fatal("Failed 'sudo apt-get install -y mysql-client' on remote machine: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+	}
+	if err = sshRun(ssh, "pkill cloud_sql_proxy", nil, &sout, &serr); err != nil {
+		t.Logf("Failed to kill any cloud_sql_proxy process: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+	} else {
+		t.Logf("Killed already running cloud_sql_proxy process.")
+	}
+	log.Printf("Copy binary to %s:%s...", *project, *vmName)
+	this, err := os.Open(proxyBinary)
+	if err != nil {
+		t.Fatalf("Couldn't open %v for reading: %v", proxyBinary, err)
+	}
+	err = sshRun(ssh, "bash -c 'cat >cloud_sql_proxy; chmod +x cloud_sql_proxy; mkdir -p cloudsql'", this, &sout, &serr)
+	this.Close()
+	if err != nil {
+		t.Fatalf("Couldn't scp to remote machine: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+	}
+	logs, err := startProxy(ssh, "./cloud_sql_proxy -dir cloudsql -instances "+strings.Join(append([]string{*databaseName}, proxyArgs...), " "))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logs.Close()
+	// TODO: Instead of discarding all of the logs, verify that certain logs
+	// happen during connects/disconnects.
+	go io.Copy(ioutil.Discard, logs)
+	t.Logf("Cloud SQL Proxy started on remote host")
+	return err, ssh
+}
+
+var _ io.ReadCloser = (*process)(nil)
+
+// process wraps a remotely executing process, turning it into an
+// io.ReadCloser.
+type process struct {
+	io.Reader
+	sess *ssh.Session
+}
+
+// TODO: Return the value of 'Wait'ing on the process. ssh.Session.Signal
+// doesn't seem to have an effect, so calling it and then doing Wait doesn't do
+// anything. Closing the session is the only way to clean up until I figure out
+// what's wrong.
+func (p *process) Close() error {
+	return p.sess.Close()
+}
+
+func compileProxy() (binaryPath string, _ error) {
+	// Find the 'build.sh' script by looking for it in cwd, cwd/.., and cwd/../..
+	var buildSh string
+
+	var parentPath []string
+	for parents := 0; parents < 2; parents++ {
+		cur := filepath.Join(append(parentPath, buildShLocation)...)
+		if _, err := os.Stat(cur); err == nil {
+			buildSh = cur
+			break
+		}
+		parentPath = append(parentPath, "..")
+	}
+	if buildSh == "" {
+		return "", fmt.Errorf("couldn't find %q; please cd into the local repository", buildShLocation)
+	}
+
+	cmd := exec.Command(buildSh)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("error during build.sh execution: %v;\n%s", err, out)
+	}
+
+	return "cloud_sql_proxy", nil
+}
+
+// startProxy executes the cloud_sql_proxy via ssh. The returned ReadCloser
+// must be serviced and closed when finished, otherwise the SSH connection may
+// block.
+func startProxy(ssh *ssh.Client, args string) (io.ReadCloser, error) {
+	sess, err := ssh.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't open new session: %v", err)
+	}
+	pr, err := sess.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Running proxy...")
+	if err := sess.Start(args); err != nil {
+		return nil, err
+	}
+
+	// The proxy prints "Ready for new connections" after it starts up
+	// correctly. Start a new goroutine looking for that value so that we can
+	// time-out appropriately (in case something weird is going on).
+	in := bufio.NewReader(pr)
+	buf := new(bytes.Buffer)
+	errCh := make(chan error, 1)
+	go func() {
+		for {
+			bs, err := in.ReadBytes('\n')
+			if err != nil {
+				if err == io.EOF {
+					log.Print("reading stderr gave EOF (remote process closed)")
+					err = sess.Wait()
+				}
+				errCh <- fmt.Errorf("failed to run `%s`: %v", args, err)
+				return
+			}
+			buf.Write(bs)
+			if bytes.Contains(bs, []byte("Ready for new connections")) {
+				errCh <- nil
+				return
+			}
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return nil, err
+		}
+
+		// Proxy process startup succeeded.
+		return &process{
+			io.MultiReader(buf, in),
+			sess,
+		}, nil
+	case <-time.After(3 * time.Second):
+		log.Printf("Timeout starting up `%v`", args)
+	}
+
+	// Starting the proxy timed out, so we should close the SSH session and
+	// return an error after the process exits.
+	// TODO: the sess.Signal method doesn't seem to work... that's what we
+	// really want to do.
+	err = sess.Close()
+	select {
+	case waitErr := <-errCh:
+		if err == nil {
+			err = waitErr
+		}
+	case <-time.After(2 * time.Second):
+		log.Printf("Timeout while waiting for process after closing SSH session.")
+		if err == nil {
+			err = errors.New("timeout waiting for SSH connection to close")
+		}
+	}
+	return nil, fmt.Errorf("timeout waiting for `%v`: error from close: %v; output was:\n\n%s", args, err, buf)
+}
+
+func sshRun(ssh *ssh.Client, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
+	sess, err := ssh.NewSession()
+	if err != nil {
+		return err
+	}
+
+	sess.Stdin = stdin
+	if stderr == nil && stdout == nil {
+		if out, err := sess.CombinedOutput(cmd); err != nil {
+			return fmt.Errorf("`%v`: %v; combined output was:\n%s", cmd, err, out)
+		}
+		return nil
+	}
+	sess.Stdout = stdout
+	sess.Stderr = stderr
+
+	return sess.Run(cmd)
+}
+
+func newOrReuseVM(logf func(string, ...interface{}), cl *http.Client) (*ssh.Client, error) {
+	c, err := compute.New(cl)
+	if err != nil {
+		return nil, err
+	}
+
+	user := "test-user"
+	pub, auth, err := sshKey()
+	if err != nil {
+		return nil, err
+	}
+	sshPubKey := user + ":" + pub
+
+	var op *compute.Operation
+
+	if inst, err := c.Instances.Get(*project, *zone, *vmName).Do(); err != nil {
+		logf("Creating new instance (getting instance %v in project %v and zone %v failed: %v)", *vmName, *project, *zone, err)
+		instProto := &compute.Instance{
+			Name:        *vmName,
+			MachineType: "zones/" + *zone + "/machineTypes/g1-small",
+			Disks: []*compute.AttachedDisk{{
+				AutoDelete: true,
+				Boot:       true,
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					SourceImage: *osImage,
+					DiskSizeGb:  10,
+				}},
+			},
+			NetworkInterfaces: []*compute.NetworkInterface{{
+				Network:       "projects/" + *project + "/global/networks/default",
+				AccessConfigs: []*compute.AccessConfig{{Name: "External NAT", Type: "ONE_TO_ONE_NAT"}},
+			}},
+			Metadata: &compute.Metadata{
+				Items: []*compute.MetadataItems{{
+					Key: "sshKeys", Value: &sshPubKey,
+				}},
+			},
+			Tags: &compute.Tags{Items: []string{"ssh"}},
+			ServiceAccounts: []*compute.ServiceAccount{{
+				Email:  "default",
+				Scopes: []string{proxy.SQLScope},
+			}},
+		}
+		op, err = c.Instances.Insert(*project, *zone, instProto).Do()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		logf("attempting to reuse instance %v (in project %v and zone %v)...", *vmName, *project, *zone)
+		set := false
+		md := inst.Metadata
+		for _, v := range md.Items {
+			if v.Key == "sshKeys" {
+				v.Value = &sshPubKey
+				set = true
+				break
+			}
+		}
+		if !set {
+			md.Items = append(md.Items, &compute.MetadataItems{Key: "sshKeys", Value: &sshPubKey})
+		}
+		op, err = c.Instances.SetMetadata(*project, *zone, *vmName, md).Do()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for {
+		if op.Error != nil && len(op.Error.Errors) > 0 {
+			return nil, fmt.Errorf("errors: %v", op.Error.Errors)
+		}
+
+		log.Printf("%v %v (%v)", op.OperationType, op.TargetLink, op.Status)
+		if op.Status == "DONE" {
+			break
+		}
+		time.Sleep(5 * time.Second)
+
+		op, err = c.ZoneOperations.Get(*project, *zone, op.Name).Do()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	inst, err := c.Instances.Get(*project, *zone, *vmName).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error getting instance after it was created: %v", err)
+	}
+	ip := inst.NetworkInterfaces[0].AccessConfigs[0].NatIP
+
+	var lastErr error
+	for try := 0; try < 10; try++ {
+		if lastErr != nil {
+			const sleepTime = 10 * time.Second
+			logging.Errorf("%v; sleeping for %v then retrying", lastErr, sleepTime)
+			time.Sleep(sleepTime)
+		}
+		ssh, err := ssh.Dial("tcp", ip+":22", &ssh.ClientConfig{
+			User:            user,
+			Auth:            []ssh.AuthMethod{auth},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		})
+		if err == nil {
+			return ssh, nil
+		}
+		lastErr = fmt.Errorf("couldn't ssh to %v (IP=%v): %v", *vmName, ip, err)
+	}
+	return nil, lastErr
+}
+
+func sshKey() (pubKey string, auth ssh.AuthMethod, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", nil, err
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return "", nil, err
+	}
+	pub, err := ssh.NewPublicKey(&key.PublicKey)
+	if err != nil {
+		return "", nil, err
+	}
+	return string(ssh.MarshalAuthorizedKey(pub)), ssh.PublicKeys(signer), nil
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	switch "" {
+	case *project:
+		log.Fatal("Must set -project")
+	case *databaseName:
+		log.Fatal("Must set -db_name")
+	}
+
+	os.Exit(m.Run())
+}

--- a/tests/common.go
+++ b/tests/common.go
@@ -89,7 +89,7 @@ func setupGCEProxy(t *testing.T, proxyArgs []string) (error, *ssh.Client) {
 		t.Fatal("Failed 'sudo apt-get install -y mysql-client' on remote machine: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
 	}
 	if err = sshRun(ssh, "pkill cloud_sql_proxy", nil, &sout, &serr); err != nil {
-		t.Logf("Failed to kill any cloud_sql_proxy process: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+		t.Logf("Failed to kill any cloud_sql_proxy process.")
 	} else {
 		t.Logf("Killed already running cloud_sql_proxy process.")
 	}

--- a/tests/connection_limit_test.go
+++ b/tests/connection_limit_test.go
@@ -24,7 +24,7 @@
 //    -db_name, -project
 //
 // Example invocation:
-//     go test -v -run TestGCE -args -project=my-project -db_name=my-project:the-region:sql-name
+//     go test -v -run TestConnectionLimit -args -project=my-project -db_name=my-project:the-region:sql-name
 package tests
 
 import (
@@ -33,11 +33,12 @@ import (
 	"testing"
 )
 
-// TestGCE provisions a new GCE VM and verifies that the proxy works on it.
+// TestConnectionLimit provisions a new GCE VM and verifies that the proxy works on it.
 // It uses application default credentials.
-func TestGCE(t *testing.T) {
+func TestConnectionLimit(t *testing.T) {
 	err, ssh := setupGCEProxy(t, nil)
 
+	// TODO: implement actual test
 	cmd := fmt.Sprintf(`mysql -uroot -S cloudsql/%s -e "select 1\\G"`, *databaseName)
 	var sout, serr bytes.Buffer
 	if err = sshRun(ssh, cmd, nil, &sout, &serr); err != nil {

--- a/tests/connection_limit_test.go
+++ b/tests/connection_limit_test.go
@@ -48,7 +48,7 @@ func TestConnectionLimit(t *testing.T) {
 			log.Print("Starting blocking mysql command")
 			var sout, serr bytes.Buffer
 			if err = sshRun(ssh, cmd, nil, &sout, &serr); err != nil {
-				t.Fatalf("Error running mysql: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+				t.Errorf("Error running mysql: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
 			}
 			t.Logf("Blocking command output %s", &sout)
 		}()

--- a/tests/connection_limit_test.go
+++ b/tests/connection_limit_test.go
@@ -31,18 +31,35 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
+	"log"
 )
 
 // TestConnectionLimit provisions a new GCE VM and verifies that the proxy works on it.
 // It uses application default credentials.
 func TestConnectionLimit(t *testing.T) {
-	err, ssh := setupGCEProxy(t, nil)
+	err, ssh := setupGCEProxy(t, []string{"-max_connections", "5"})
 
-	// TODO: implement actual test
-	cmd := fmt.Sprintf(`mysql -uroot -S cloudsql/%s -e "select 1\\G"`, *databaseName)
-	var sout, serr bytes.Buffer
-	if err = sshRun(ssh, cmd, nil, &sout, &serr); err != nil {
-		t.Fatalf("Error running mysql: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+	cmd := fmt.Sprintf(`mysql -uroot -S cloudsql/%s -e "SELECT 1; SELECT SLEEP(120);"`, *databaseName)
+
+	// Use less than the sshd MaxStartups configuration (defaults to 10)
+	for i := 0; i < 5; i++ {
+		go func() {
+			log.Print("Starting blocking mysql command")
+			var sout, serr bytes.Buffer
+			if err = sshRun(ssh, cmd, nil, &sout, &serr); err != nil {
+				t.Fatalf("Error running mysql: %v\n\nstandard out:\n%s\nstandard err:\n%s", err, &sout, &serr)
+			}
+			t.Logf("Blocking command output %s", &sout)
+		}()
 	}
-	t.Log(&sout)
+
+	time.Sleep(time.Second * 5)
+	var sout, serr bytes.Buffer
+	log.Print("Test connection refusal")
+	cmd = fmt.Sprintf(`mysql -uroot -S cloudsql/%s -e "SELECT 1;"`, *databaseName)
+	if err = sshRun(ssh, cmd, nil, &sout, &serr); err == nil {
+		t.Fatalf("Mysql connection should have been refused:\n\nstandard out:\n%s\nstandard err:\n%s", &sout, &serr)
+	}
+	t.Logf("Test command output %s", &sout)
 }

--- a/tests/dialers_test.go
+++ b/tests/dialers_test.go
@@ -21,11 +21,11 @@
 //
 // Example invocations:
 //   Using default credentials
-//     go test -v dialers_test.go -args -db_name=my-project:the-region:instance-name
+//     go test -v -run TestDialer -args -db_name=my-project:the-region:instance-name
 //   Using a service account credentials json file
-//     go test -v dialers_test.go -args -db_name=my-project:the-region:instance-name -credential_file /path/to/credentials.json
+//     go test -v -run TestDialer -args -db_name=my-project:the-region:instance-name -credential_file /path/to/credentials.json
 //   Using an access token
-//     go test -v dialers_test.go -args -db_name=my-project:the-region:instance-name -token "an access token"
+//     go test -v -run TestDialer -args -db_name=my-project:the-region:instance-name -token "an access token"
 package tests
 
 import (
@@ -45,11 +45,10 @@ import (
 )
 
 var (
-	databaseName = flag.String("db_name", "", "Fully-qualified Cloud SQL Instance (in the form of 'project:region:instance-name')")
-	dbUser       = flag.String("db_user", "root", "Name of user to use during test")
-	dbPassword   = flag.String("db_pass", "", "Password for user; be careful when entering a password on the command line (it may go into your terminal's history). Also note that using a password along with the Cloud SQL Proxy is not necessary as long as you set the hostname of the user appropriately (see https://cloud.google.com/sql/docs/sql-proxy#user)")
-	tokenFile    = flag.String("credential_file", "", `If provided, this json file will be used to retrieve Service Account credentials. You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same effect.`)
-	token        = flag.String("token", "", "When set, the proxy uses this Bearer token for authorization.")
+	dbUser     = flag.String("db_user", "root", "Name of user to use during test")
+	dbPassword = flag.String("db_pass", "", "Password for user; be careful when entering a password on the command line (it may go into your terminal's history). Also note that using a password along with the Cloud SQL Proxy is not necessary as long as you set the hostname of the user appropriately (see https://cloud.google.com/sql/docs/sql-proxy#user)")
+	tokenFile  = flag.String("credential_file", "", `If provided, this json file will be used to retrieve Service Account credentials. You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same effect.`)
+	token      = flag.String("token", "", "When set, the proxy uses this Bearer token for authorization.")
 )
 
 // TestDialer verifies that the mysql dialer works as expected. It assumes that


### PR DESCRIPTION
This is a first shot at trying to implement a hard limit on the number of connections to accept before refusing new connections to avoid OOM when memory resources are limited, as suggested by @Carrotman42 in #103.

TODO:

- [x] Add connections counter with atomic increments
- [x] Unit test
- [x] End to end test
