### PR TITLE
Remove the use of the ConnSet when it is not required.

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -57,8 +57,11 @@ type Client struct {
 	// Port designates which remote port should be used when connecting to
 	// instances. This value is defined by the server-side code, but for now it
 	// should always be 3307.
-	Port  int
+	Port int
+	// Required; specifies how certificates are obtained.
 	Certs CertSource
+	// Optionally tracks connections through this client. If nil, connections
+	// are not tracked and will not be closed before method Run exits.
 	Conns *ConnSet
 	// Dialer should return a new connection to the provided address. It is
 	// called on each new connection to an instance. net.Dial will be used if

--- a/proxy/proxy/dial.go
+++ b/proxy/proxy/dial.go
@@ -68,9 +68,6 @@ type Dialer func(net, addr string) (net.Conn, error)
 // The connset parameter is optional.
 // If the dialer is nil, net.Conn is used.
 func Init(auth *http.Client, connset *ConnSet, dialer Dialer) {
-	if connset == nil {
-		connset = NewConnSet()
-	}
 	dialClient.Lock()
 	dialClient.c = &Client{
 		Port:   port,


### PR DESCRIPTION
In the Client Proxy binary it is only used in FUSE mode, so only set it there. For most users this will change some O(n) operations to no-ops, which is nice.