### PR TITLE
Invalid Kubernetes config

### DIFF
--- a/Kubernetes.md
+++ b/Kubernetes.md
@@ -79,9 +79,9 @@ spec:
         - -instances=project:database1=tcp:0.0.0.0:3306,project:database2=tcp:0.0.0.0:3307
         - -credential_file=/credentials/credentials.json
         ports:
-        - name: sqlproxy-port-database1
+        - name: port-database1
           containerPort: 3306
-	- name: sqlproxy-port-database2
+	- name: port-database2
 	  containerPort: 3307
         volumeMounts:
         - mountPath: /cloudsql
@@ -124,7 +124,7 @@ metadata:
 spec:
   ports:
   - port: 3306
-    targetPort: sqlproxy-port-database1
+    targetPort: port-database1
   selector:
     app: cloudsqlproxy
 ---
@@ -135,7 +135,7 @@ metadata:
 spec:
   ports:
   - port: 3306
-    targetPort: sqlproxy-port-database2
+    targetPort: port-database2
   selector:
     app: cloudsqlproxy
 ```


### PR DESCRIPTION
Running the example yields this error:
```
Error from server (Invalid): error when creating "/dev/fd/63": DaemonSet.extensions "cloudsqlproxy" is invalid: spec.template.spec.containers[0].ports[0].name: Invalid value: "sqlproxy-port-database1": must be no more than 15 characters
Error from server (Invalid): error when creating "/dev/fd/63": Service "sqlproxy-service-database1" is invalid: spec.ports[0].targetPort: Invalid value: "sqlproxy-port-database1": must be no more than 15 characters
```