### PR TITLE
cmd: use INSTANCES env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cloud_sql_proxy takes a few arguments to configure:
   directory indicated by `-dir` is mounted.
 * `-instances="project1:region:instance1,project3:region:instance1"`: A comma-separated list
   of instances to open inside `-dir`. Also supports exposing a tcp port instead of using Unix Domain Sockets; see examples below.
+  Same list can be provided via INSTANCES environment variable, in case when both are provided - proxy will use command line flag.
 * `-instances_metadata=metadata_key`: Usable on [GCE](https://cloud.google.com/compute/docs/quickstart) only. The given [GCE metadata](https://cloud.google.com/compute/docs/metadata) key will be
   polled for a list of instances to open in `-dir`. The format for the value is the same as the 'instances' flag. A hanging-poll strategy is used, meaning that changes to
   the metadata value will be reflected in the `-dir` even while the proxy is


### PR DESCRIPTION
in spirit of keeping manifest files same across different projects,
it'd be good to pass some config options via environment variables.
with this change, one can pass either flag -instances or INSTANCES
environment variable to get same results
