### PR TITLE
Gracefully handle Temporary errors from Accept()

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -142,6 +142,9 @@ func listenInstance(dst chan<- proxy.Conn, cfg instanceConfig) (net.Listener, er
 			c, err := l.Accept()
 			if err != nil {
 				logging.Errorf("Error in accept for %q on %v: %v", cfg, cfg.Address, err)
+				if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+					continue
+				}
 				l.Close()
 				return
 			}

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/fuse"
@@ -139,10 +140,15 @@ func listenInstance(dst chan<- proxy.Conn, cfg instanceConfig) (net.Listener, er
 
 	go func() {
 		for {
+			start := time.Now()
 			c, err := l.Accept()
 			if err != nil {
 				logging.Errorf("Error in accept for %q on %v: %v", cfg, cfg.Address, err)
 				if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+					d := 10*time.Millisecond - time.Since(start)
+					if d > 0 {
+						time.Sleep(d)
+					}
 					continue
 				}
 				l.Close()

--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -42,6 +42,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -281,10 +282,15 @@ func (r *fsRoot) removeListener(instance, path string) {
 // r.newConn is called. After the Listener returns an error it is removed.
 func (r *fsRoot) listenerLifecycle(l net.Listener, instance, path string) {
 	for {
+		start := time.Now()
 		c, err := l.Accept()
 		if err != nil {
 			logging.Errorf("error in Accept for %q: %v", instance, err)
 			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+				d := 10*time.Millisecond - time.Since(start)
+				if d > 0 {
+					time.Sleep(d)
+				}
 				continue
 			}
 			break

--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -284,6 +284,9 @@ func (r *fsRoot) listenerLifecycle(l net.Listener, instance, path string) {
 		c, err := l.Accept()
 		if err != nil {
 			logging.Errorf("error in Accept for %q: %v", instance, err)
+			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+				continue
+			}
 			break
 		}
 		r.newConn(instance, c)

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -271,6 +271,9 @@ func NewConnSrc(instance string, l net.Listener) <-chan Conn {
 			c, err := l.Accept()
 			if err != nil {
 				logging.Errorf("listener (%#v) had error: %v", l, err)
+				if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+					continue
+				}
 				l.Close()
 				close(ch)
 				return

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -268,10 +268,15 @@ func NewConnSrc(instance string, l net.Listener) <-chan Conn {
 	ch := make(chan Conn)
 	go func() {
 		for {
+			start := time.Now()
 			c, err := l.Accept()
 			if err != nil {
 				logging.Errorf("listener (%#v) had error: %v", l, err)
 				if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+					d := 10*time.Millisecond - time.Since(start)
+					if d > 0 {
+						time.Sleep(d)
+					}
 					continue
 				}
 				l.Close()


### PR DESCRIPTION
This should prevent the Cloud SQL proxy from dying once it e.g. hits the
max filedescriptor limit.