### PR TITLE
Stdout and Stderr Loggers

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -48,9 +48,10 @@ import (
 )
 
 var (
-	version = flag.Bool("version", false, "Print the version of the proxy and exit")
-	verbose = flag.Bool("verbose", true, "If false, verbose output such as information about when connections are created/closed without error are suppressed")
-	quiet   = flag.Bool("quiet", false, "Disable log messages")
+	version        = flag.Bool("version", false, "Print the version of the proxy and exit")
+	verbose        = flag.Bool("verbose", true, "If false, verbose output such as information about when connections are created/closed without error are suppressed")
+	quiet          = flag.Bool("quiet", false, "Disable log messages")
+	logDebugStdout = flag.Bool("log_debug_stdout", false, "If true, log messages that are not errors will outout to stdout instead of stderr")
 
 	refreshCfgThrottle = flag.Duration("refresh_config_throttle", proxy.DefaultRefreshCfgThrottle, "If set, this flag specifies the amount of forced sleep between successive API calls in order to protect client API quota. Minimum allowed value is "+minimumRefreshCfgThrottle.String())
 	checkRegion        = flag.Bool("check_region", false, `If specified, the 'region' portion of the connection string is required for
@@ -119,6 +120,9 @@ General:
     WARNING: this option disables ALL logging output (including connection
     errors), which will likely make debugging difficult. The -quiet flag takes
     precedence over the -verbose flag.
+  -log_debug_stdout
+    When explicitly set to true, verbose and info log messages will be directed
+	stdout as a pose to the default stderr.
   -verbose
     When explicitly set to false, disable log messages that are not errors nor
     first-time startup messages (e.g. when new connections are established).
@@ -380,6 +384,10 @@ func main() {
 	if *version {
 		fmt.Println("Cloud SQL Proxy:", versionString)
 		return
+	}
+
+	if *logDebugStdout {
+		logging.LogDebugToStdout()
 	}
 
 	if !*verbose {

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -122,7 +122,7 @@ General:
     precedence over the -verbose flag.
   -log_debug_stdout
     When explicitly set to true, verbose and info log messages will be directed
-	stdout as a pose to the default stderr.
+	to stdout as a pose to the default stderr.
   -verbose
     When explicitly set to false, disable log messages that are not errors nor
     first-time startup messages (e.g. when new connections are established).

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -51,7 +51,7 @@ var (
 	version        = flag.Bool("version", false, "Print the version of the proxy and exit")
 	verbose        = flag.Bool("verbose", true, "If false, verbose output such as information about when connections are created/closed without error are suppressed")
 	quiet          = flag.Bool("quiet", false, "Disable log messages")
-	logDebugStdout = flag.Bool("log_debug_stdout", false, "If true, log messages that are not errors will outout to stdout instead of stderr")
+	logDebugStdout = flag.Bool("log_debug_stdout", false, "If true, log messages that are not errors will output to stdout instead of stderr")
 
 	refreshCfgThrottle = flag.Duration("refresh_config_throttle", proxy.DefaultRefreshCfgThrottle, "If set, this flag specifies the amount of forced sleep between successive API calls in order to protect client API quota. Minimum allowed value is "+minimumRefreshCfgThrottle.String())
 	checkRegion        = flag.Bool("check_region", false, `If specified, the 'region' portion of the connection string is required for

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -391,7 +391,7 @@ func main() {
 	}
 
 	if !*verbose {
-		logging.Verbosef = func(string, ...interface{}) {}
+		logging.LogVerboseToNowhere()
 	}
 
 	if *quiet {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -32,9 +32,14 @@ var Infof = log.Printf
 // Errorf is called to write an error log, such as when a new connection fails.
 var Errorf = log.Printf
 
-// LogDebugToStdout updates Verbose and Info logging to use stdout instead of stderr.
+// LogDebugToStdout updates Verbosef and Info logging to use stdout instead of stderr.
 func LogDebugToStdout() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	Verbosef = logger.Printf
 	Infof = logger.Printf
+}
+
+// LogVerboseToNowhere updates Verbosef so verbose log messages are discarded
+func LogVerboseToNowhere() {
+	Verbosef = func(string, ...interface{}) {}
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -23,6 +23,7 @@ import (
 )
 
 // Verbosef is called to write verbose logs, such as when a new connection is
+// established correctly.
 var Verbosef = log.Printf
 
 // Infof is called to write informational logs, such as when startup has

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -22,20 +22,18 @@ import (
 	"os"
 )
 
-// Loggers for logging to stdout and stderr
-var (
-	stdout = log.New(os.Stdout, "", log.LstdFlags)
-	stderr = log.New(os.Stderr, "", log.LstdFlags)
-)
-
 // Verbosef is called to write verbose logs, such as when a new connection is
-// established correctly. Logs to srdout.
-var Verbosef = stdout.Printf
+var Verbosef = log.Printf
 
 // Infof is called to write informational logs, such as when startup has
-// completed. Logs to stdout.
-var Infof = stdout.Printf
+var Infof = log.Printf
 
 // Errorf is called to write an error log, such as when a new connection fails.
-// Logs to stderr.
-var Errorf = stderr.Printf
+var Errorf = log.Printf
+
+// LogDebugToStdout updates Verbose and Info logging to use stdout instead of stderr.
+func LogDebugToStdout() {
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+	Verbosef = logger.Printf
+	Infof = logger.Printf
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -17,15 +17,25 @@
 // control where log messages end up.
 package logging
 
-import "log"
+import (
+	"log"
+	"os"
+)
+
+// Loggers for logging to stdout and stderr
+var (
+	stdout = log.New(os.Stdout, "", log.LstdFlags)
+	stderr = log.New(os.Stderr, "", log.LstdFlags)
+)
 
 // Verbosef is called to write verbose logs, such as when a new connection is
-// established correctly.
-var Verbosef = log.Printf
+// established correctly. Logs to srdout.
+var Verbosef = stdout.Printf
 
 // Infof is called to write informational logs, such as when startup has
-// completed.
-var Infof = log.Printf
+// completed. Logs to stdout.
+var Infof = stdout.Printf
 
 // Errorf is called to write an error log, such as when a new connection fails.
-var Errorf = log.Printf
+// Logs to stderr.
+var Errorf = stderr.Printf


### PR DESCRIPTION
Related issues: #106 #138 #149 

We noticed that debug messages from our Cloud SQL proxy would be considered as errors in stack driver since all log messages are sent to `stderr` as is defined by the default logger in the go log package: https://golang.org/src/log/log.go?#L73

This Pull requests sets up two new loggers, one for verbose / info messages which log to `stdout` and one for error messages which log to `stderr`.

I believe this should fix the problems as described in #138