### PR TITLE
Automatically refresh SSL certs before they expire, part 2

### DIFF
--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -28,7 +28,10 @@ import (
 
 const instance = "instance-name"
 
-var errFakeDial = errors.New("this error is returned by the dialer")
+var (
+	errFakeDial = errors.New("this error is returned by the dialer")
+	forever     = time.Date(9999, 0, 0, 0, 0, 0, 0, time.UTC)
+)
 
 type fakeCerts struct {
 	sync.Mutex
@@ -36,7 +39,8 @@ type fakeCerts struct {
 }
 
 type blockingCertSource struct {
-	values map[string]*fakeCerts
+	values     map[string]*fakeCerts
+	validUntil time.Time
 }
 
 func (cs *blockingCertSource) Local(instance string) (tls.Certificate, error) {
@@ -48,11 +52,10 @@ func (cs *blockingCertSource) Local(instance string) (tls.Certificate, error) {
 	v.called++
 	v.Unlock()
 
-	validUntil, _ := time.Parse("2006", "9999")
 	// Returns a cert which is valid forever.
 	return tls.Certificate{
 		Leaf: &x509.Certificate{
-			NotAfter: validUntil,
+			NotAfter: cs.validUntil,
 		},
 	}, nil
 }
@@ -67,7 +70,9 @@ func TestClientCache(t *testing.T) {
 		Certs: &blockingCertSource{
 			map[string]*fakeCerts{
 				instance: b,
-			}},
+			},
+			forever,
+		},
 		Dialer: func(string, string) (net.Conn, error) {
 			return nil, errFakeDial
 		},
@@ -92,7 +97,9 @@ func TestConcurrentRefresh(t *testing.T) {
 		Certs: &blockingCertSource{
 			map[string]*fakeCerts{
 				instance: b,
-			}},
+			},
+			forever,
+		},
 		Dialer: func(string, string) (net.Conn, error) {
 			return nil, errFakeDial
 		},
@@ -131,7 +138,9 @@ func TestMaximumConnectionsCount(t *testing.T) {
 
 	b := &fakeCerts{}
 	certSource := blockingCertSource{
-		map[string]*fakeCerts{}}
+		map[string]*fakeCerts{},
+		forever,
+	}
 	firstDialExited := make(chan struct{})
 	c := &Client{
 		Certs: &certSource,
@@ -181,5 +190,56 @@ func TestMaximumConnectionsCount(t *testing.T) {
 		t.Logf("client has correctly refused to dial new connection on %dth attempt when the maximum of %d connections was reached (%d dials)\n", numConnections, maxConnections, dials)
 	case dials < maxConnections:
 		t.Errorf("client should have dialed exactly the maximum of %d connections (%d connections, %d dials)", maxConnections, numConnections, dials)
+	}
+}
+
+func TestRefreshTimer(t *testing.T) {
+	refreshCertBuffer = time.Millisecond * 10
+	timeToExpire := time.Millisecond * 500
+	b := &fakeCerts{}
+	c := &Client{
+		Certs: &blockingCertSource{
+			map[string]*fakeCerts{
+				instance: b,
+			},
+			time.Now().Add(timeToExpire),
+		},
+		Dialer: func(string, string) (net.Conn, error) {
+			return nil, errFakeDial
+		},
+		RefreshCfgThrottle: 20 * time.Millisecond,
+	}
+
+	// Call Dial to cache the cert.
+	if _, err := c.Dial(instance); err != errFakeDial {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	c.cacheL.Lock()
+	cached, ok := c.cfgCache[instance]
+	c.cacheL.Unlock()
+	if !ok {
+		t.Error("expected instance to be cached")
+	}
+	waitTil := time.After(timeToExpire + (10 * time.Millisecond))
+loop:
+	for {
+		select {
+		case <-waitTil:
+			break loop
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// Verify cert was refreshed in the background, without calling Dial again.
+	c.cacheL.Lock()
+	refreshed, ok := c.cfgCache[instance]
+	c.cacheL.Unlock()
+	if !ok {
+		t.Error("expected instance to be cached")
+	}
+	if !refreshed.lastRefreshed.After(cached.lastRefreshed) {
+		t.Error("expected cert to be refreshed.")
 	}
 }


### PR DESCRIPTION
For issue #94, Follow up of https://github.com/GoogleCloudPlatform/cloudsql-proxy/pull/142 which was reverted due to some unaddressed comments.