### PR TITLE
Use NewConfig() to initialize mysql.Config with correct defaults

### DIFF
--- a/proxy/dialers/mysql/hook.go
+++ b/proxy/dialers/mysql/hook.go
@@ -38,12 +38,10 @@ func init() {
 // The returned *sql.DB may be valid even if there's also an error returned
 // (e.g. if there was a transient connection error).
 func Dial(instance, user string) (*sql.DB, error) {
-	return DialCfg(&mysql.Config{
-		User: user,
-		Addr: instance,
-		// Set in DialCfg:
-		// Net: "cloudsql",
-	})
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Addr = instance
+	return DialCfg(cfg)
 }
 
 // DialPassword is similar to Dial, but allows you to specify a password.
@@ -53,13 +51,11 @@ func Dial(instance, user string) (*sql.DB, error) {
 // information, see:
 //    https://cloud.google.com/sql/docs/sql-proxy#user
 func DialPassword(instance, user, password string) (*sql.DB, error) {
-	return DialCfg(&mysql.Config{
-		User:   user,
-		Passwd: password,
-		Addr:   instance,
-		// Set in DialCfg:
-		// Net: "cloudsql",
-	})
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.Addr = instance
+	return DialCfg(cfg)
 }
 
 // Cfg returns the effective *mysql.Config to represent connectivity to the
@@ -67,12 +63,12 @@ func DialPassword(instance, user, password string) (*sql.DB, error) {
 // modified and passed to DialCfg to connect. If you don't modify the returned
 // config before dialing, consider using Dial or DialPassword.
 func Cfg(instance, user, password string) *mysql.Config {
-	return &mysql.Config{
-		Addr:   instance,
-		User:   user,
-		Passwd: password,
-		Net:    "cloudsql",
-	}
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.Addr = instance
+	cfg.Net = "cloudsql"
+	return cfg
 }
 
 // DialCfg opens up a SQL connection to a Cloud SQL Instance specified by the


### PR DESCRIPTION
The [go-sql-driver 1.4](https://github.com/go-sql-driver/mysql/blob/master/CHANGELOG.md#version-14-2018-06-03) release mentions the following change:
```
- Allow native password authentication by default (#644)
- NewConfig function which initializes a config with default values (#679)
```

The mysql.Config setting [AllowNativePasswords](https://github.com/go-sql-driver/mysql/blob/master/dsn.go#L55) should thus be default true, and it's correctly initialized when using the [NewConfig()](https://github.com/go-sql-driver/mysql/blob/master/dsn.go#L66) function. This cloudsql dialer code however currently does not use that constructor, instead it creates a *mysql.Config struct itself. This means `AllowNativePasswords` is uninitialized and false, which is not the correct default or expected behaviour. 

Relevant discussion and explanation can also be found here https://github.com/go-sql-driver/mysql/pull/644#issuecomment-394266484