### PR TITLE
add support for watching instances via file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cloud_sql_proxy takes a few arguments to configure:
   will be removed from `-dir` as well (unless it was also specified in
   `-instances`), but any existing connections to this instance will NOT be
   terminated.
+* `-instances_file="/path/to/instances/file"`: Specify a file to load and watch for instances configuration changes. It's a comma separated list similar to the `-instances` param value.
 
 Note: `-instances` and `-instances_metadata` may be used at the same time but
 are not compatible with the `-fuse` flag.

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -296,7 +296,7 @@ func authenticatedClient(ctx context.Context) (*http.Client, error) {
 }
 
 func stringList(s string) []string {
-	spl := strings.Split(s, ",")
+	spl := strings.Split(strings.TrimSpace(s), ",")
 	if len(spl) == 1 && spl[0] == "" {
 		return nil
 	}
@@ -429,7 +429,7 @@ func main() {
 		if err != nil {
 			logging.Errorf("Error reading configuration file: %v", err)
 		}
-		*instances = strings.TrimSpace(string(configurationBytes))
+		*instances = string(configurationBytes)
 	}
 
 	// TODO: needs a better place for consolidation
@@ -516,7 +516,7 @@ func main() {
 						if err != nil {
 							logging.Errorf("Error reading configuration file: %v", err)
 						}
-						configuration := strings.TrimSpace(string(configurationBytes))
+						configuration := string(configurationBytes)
 						logging.Infof("configuration updated: %v", configuration)
 						updates <- configuration
 					case err := <-watcher.Errors:

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -63,7 +63,7 @@ func WatchInstances(dir string, cfgs []instanceConfig, updates <-chan string, cl
 func watchInstancesLoop(dir string, dst chan<- proxy.Conn, updates <-chan string, static map[string]net.Listener, cl *http.Client) {
 	dynamicInstances := make(map[string]net.Listener)
 	for instances := range updates {
-		list, err := parseInstanceConfigs(dir, strings.Split(instances, ","), cl)
+		list, err := parseInstanceConfigs(dir, strings.Split(strings.TrimSpace(instances), ","), cl)
 		if err != nil {
 			logging.Errorf("%v", err)
 		}


### PR DESCRIPTION
The company I work for uses confd for configuration management, and we wanted a way to reload the instances list without restarting the process. This seems to work well enough.