### PR TITLE
Use gcloud oauth token before trying application default credentials

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -349,12 +349,6 @@ func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instanc
 		}
 
 		errStr := fmt.Sprintf("no instance selected because none of %s is specified", flags)
-		switch gcloudStatus {
-		case gcloudNotFound:
-			errStr = fmt.Sprintf("%s and gcloud could not be found in the system path", errStr)
-		case gcloudExecErr:
-			errStr = fmt.Sprintf("%s and gcloud failed to get the project list", errStr)
-		}
 		return nil, errors.New(errStr)
 	}
 	return cfgs, nil

--- a/proxy/proxy/dial.go
+++ b/proxy/proxy/dial.go
@@ -21,9 +21,7 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/certs"
-	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/util"
 	"golang.org/x/net/context"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
 
@@ -88,18 +86,13 @@ func InitClient(c Client) {
 	dialClient.Unlock()
 }
 
-// InitDefault attempts to initialize the Dial function using either gcloud credentials or the
-// application default credentials.
+// InitDefault attempts to initialize the Dial function using application
+// default credentials.
 func InitDefault(ctx context.Context) error {
-	src, err := util.GcloudTokenSource(ctx)
-	if err != nil {
-		src, err = google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/sqlservice.admin")
-	}
+	cl, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/sqlservice.admin")
 	if err != nil {
 		return err
 	}
-
-	cl := oauth2.NewClient(ctx, src)
 	Init(cl, nil, nil)
 	return nil
 }

--- a/proxy/util/gcloudutil.go
+++ b/proxy/util/gcloudutil.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"os/exec"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
@@ -84,15 +83,11 @@ func GcloudConfig() (*GcloudConfigData, error) {
 	cmd.Stdout = buf
 
 	if err := cmd.Run(); err != nil {
-		if strings.Contains(err.Error(), "executable file not found") {
-			return nil, &GcloudError{err, GcloudNotFound}
-		}
 		logging.Errorf("Error detecting gcloud project: %v", err)
 		return nil, &GcloudError{err, GcloudExecErr}
 	}
 
 	data := &GcloudConfigData{}
-
 	if err := json.Unmarshal(buf.Bytes(), data); err != nil {
 		logging.Errorf("Failed to unmarshal bytes from gcloud: %v", err)
 		logging.Errorf("   gcloud returned:\n%s", buf)

--- a/proxy/util/gcloudutil.go
+++ b/proxy/util/gcloudutil.go
@@ -1,0 +1,124 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
+	"golang.org/x/oauth2"
+)
+
+// GcloudConfigData represents the data returned by `gcloud config config-helper`.
+type GcloudConfigData struct {
+	Configuration struct {
+		Properties struct {
+			Core struct {
+				Project string
+				Account string
+			}
+		}
+	}
+	Credential struct {
+		AccessToken string    `json:"access_token"`
+		TokenExpiry time.Time `json:"token_expiry"`
+	}
+}
+
+func (cfg *GcloudConfigData) oauthToken() *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken: cfg.Credential.AccessToken,
+		Expiry:      cfg.Credential.TokenExpiry,
+	}
+}
+
+type GcloudStatusCode int
+
+const (
+	GcloudOk GcloudStatusCode = iota
+	GcloudNotFound
+	// generic execution failure error not specified above.
+	GcloudExecErr
+)
+
+type GcloudError struct {
+	GcloudError error
+	Status      GcloudStatusCode
+}
+
+func (e *GcloudError) Error() string {
+	return e.GcloudError.Error()
+}
+
+// GcloudConfig returns a GcloudConfigData object or an error of type *GcloudError.
+func GcloudConfig() (*GcloudConfigData, error) {
+	gcloudCmd := "gcloud"
+	if runtime.GOOS == "windows" {
+		gcloudCmd = gcloudCmd + ".cmd"
+	}
+
+	if _, err := exec.LookPath(gcloudCmd); err != nil {
+		return nil, &GcloudError{err, GcloudNotFound}
+	}
+
+	buf := new(bytes.Buffer)
+	cmd := exec.Command(gcloudCmd, "--format", "json", "config", "config-helper")
+	cmd.Stdout = buf
+
+	if err := cmd.Run(); err != nil {
+		if strings.Contains(err.Error(), "executable file not found") {
+			return nil, &GcloudError{err, GcloudNotFound}
+		}
+		logging.Errorf("Error detecting gcloud project: %v", err)
+		return nil, &GcloudError{err, GcloudExecErr}
+	}
+
+	data := &GcloudConfigData{}
+
+	if err := json.Unmarshal(buf.Bytes(), data); err != nil {
+		logging.Errorf("Failed to unmarshal bytes from gcloud: %v", err)
+		logging.Errorf("   gcloud returned:\n%s", buf)
+		return nil, &GcloudError{err, GcloudExecErr}
+	}
+
+	return data, nil
+}
+
+// gcloudTokenSource implements oauth2.TokenSource via the `gcloud config config-helper` command.
+type gcloudTokenSource struct {
+}
+
+// Token helps gcloudTokenSource implement oauth2.TokenSource.
+func (src *gcloudTokenSource) Token() (*oauth2.Token, error) {
+	cfg, err := GcloudConfig()
+	if err != nil {
+		return nil, err
+	}
+	return cfg.oauthToken(), nil
+}
+
+func GcloudTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	cfg, err := GcloudConfig()
+	if err != nil {
+		return nil, err
+	}
+	return oauth2.ReuseTokenSource(cfg.oauthToken(), &gcloudTokenSource{}), nil
+}


### PR DESCRIPTION
gcloud and application default credentials use different GCP projects for API quota purposes. Generally for development, or if customers want to use their own credentials for audit logging purposes, we want customers to use the auth token that is setup with `gcloud auth login`, and in particular we want to recommend that application default credentials be associated with service accounts as opposed to personal identities.

There are a couple of changes to how we detect and use the gcloud active project in this PR as well:
- Use LookupPath to determine if gcloud is not in the path instead of looking for an error message in the string
- Detect the case where gcloud is set up, but has no active project
- Add support for windows, where the gcloud command is `gcloud.cmd`
- Errors when invoking gcloud to get the active project immediately exit instead of setting sentinel values for later.