### PR TITLE
Gracefully handle TERM signals

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -506,7 +506,7 @@ func main() {
 		logging.Infof("Received TERM signal. Waiting up to %s seconds before terminating.", *termTimeout)
 
 		termTime := time.Now().Add(*termTimeout)
-		for termTime.Before(time.Now()) && proxyClient.ConnectionsCounter > 0 {
+		for termTime.After(time.Now()) && proxyClient.ConnectionsCounter > 0 {
 			time.Sleep(1)
 		}
 

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -505,6 +505,9 @@ func main() {
 		<-signals
 		logging.Infof("Received TERM signal. Waiting up to %s seconds before terminating.", *termTimeout)
 
+    // Don't access new connections while terminating.
+    proxyClient.MaxConnections = 0
+
 		termTime := time.Now().Add(*termTimeout)
 		for termTime.After(time.Now()) && proxyClient.ConnectionsCounter > 0 {
 			time.Sleep(1)
@@ -513,9 +516,8 @@ func main() {
 		// Exit cleanly if there are no active connections when we exit
 		if proxyClient.ConnectionsCounter == 0 {
 			os.Exit(0)
-		} else {
-			os.Exit(2)
 		}
+		os.Exit(2)
 	}()
 
 	proxyClient.Run(connSrc)

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -78,7 +78,7 @@ can be removed automatically by this program.`)
 	// Settings for limits
 	maxConnections = flag.Uint64("max_connections", 0, `If provided, the maximum number of connections to establish before refusing new connections. Defaults to 0 (no limit)`)
 	fdRlimit       = flag.Uint64("fd_rlimit", limits.ExpectedFDs, `Sets the rlimit on the number of open file descriptors for the proxy to the provided value. If set to zero, disables attempts to set the rlimit. Defaults to a value which can support 4K connections to one instance`)
-	termTimeout    = flag.Duration("term_timeout", 0, "When set, the proxy will stop accepting new connections and wait for existing connections to close before terminating. Any connections that haven't closed after the timeout will be dropped")
+	termTimeout    = flag.Duration("term_timeout", 0, "When set, the proxy will wait for existing connections to close before terminating. Any connections that haven't closed after the timeout will be dropped")
 
 	// Settings for authentication.
 	token     = flag.String("token", "", "When set, the proxy uses this Bearer token for authorization.")

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -334,9 +334,9 @@ func (c *Client) Shutdown(termTimeout time.Duration) error {
 		time.Sleep(1)
 	}
 
-	if atomic.LoadUint64(&c.ConnectionsCounter) == 0 {
+	active := atomic.LoadUint64(&c.ConnectionsCounter)
+	if active == 0 {
 		return nil
 	}
-
-	return errors.New("Active connections still exist")
+	return fmt.Errorf("%d active connections still exist after waiting for %v", active, termTimeout)
 }

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -322,13 +322,9 @@ func NewConnSrc(instance string, l net.Listener) <-chan Conn {
 }
 
 // Shutdown waits up to a given amount of time for all active connections to
-// close. No new connections can be established after calling this method.
-// Returns an error if there are still active connections after waiting for the
-// whole length of the timeout.
+// close. Returns an error if there are still active connections after waiting
+// for the whole length of the timeout.
 func (c *Client) Shutdown(termTimeout time.Duration) error {
-	// Don't allow new connections while terminating.
-	atomic.StoreUint64(&c.MaxConnections, 0)
-
 	termTime := time.Now().Add(termTimeout)
 	for termTime.After(time.Now()) && atomic.LoadUint64(&c.ConnectionsCounter) > 0 {
 		time.Sleep(1)

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -116,7 +116,7 @@ func (c *Client) handleConn(conn Conn) {
 	// Deferred decrement of ConnectionsCounter upon connection closing
 	defer atomic.AddUint64(&c.ConnectionsCounter, ^uint64(0))
 
-	if active > c.MaxConnections && c.MaxConnections > 0 {
+	if c.MaxConnections > 0 && active > c.MaxConnections {
 		logging.Errorf("too many open connections (max %d)", c.MaxConnections)
 		conn.Conn.Close()
 		return

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -320,3 +320,23 @@ func NewConnSrc(instance string, l net.Listener) <-chan Conn {
 	}()
 	return ch
 }
+
+// Shutdown waits up to a given amount of time for all active connections to
+// close. No new connections can be established after calling this method.
+// Returns an error if there are still active connections after waiting for the
+// whole length of the timeout.
+func (c *Client) Shutdown(termTimeout time.Duration) error {
+	// Don't allow new connections while terminating.
+	atomic.StoreUint64(&c.MaxConnections, 0)
+
+	termTime := time.Now().Add(termTimeout)
+	for termTime.After(time.Now()) && atomic.LoadUint64(&c.ConnectionsCounter) > 0 {
+		time.Sleep(1)
+	}
+
+	if atomic.LoadUint64(&c.ConnectionsCounter) == 0 {
+		return nil
+	}
+
+	return errors.New("Active connections still exist")
+}

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -202,8 +202,15 @@ func TestShutdownTerminatesEarly(t *testing.T) {
 		shutdown <- true
 	}()
 
-	time.Sleep(100 * time.Millisecond)
-	if !<-shutdown {
+	shutdownFinished := false
+
+	// In case the code is actually broken and the client doesn't shut down quickly, don't cause the test to hang until it times out.
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case shutdownFinished = <-shutdown:
+	}
+
+	if !shutdownFinished {
 		t.Errorf("shutdown should have completed quickly because there are no active connections")
 	}
 

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -183,3 +183,28 @@ func TestMaximumConnectionsCount(t *testing.T) {
 		t.Errorf("client should have dialed exactly the maximum of %d connections (%d connections, %d dials)", maxConnections, numConnections, dials)
 	}
 }
+
+func TestShutdownTerminatesEarly(t *testing.T) {
+	b := &fakeCerts{}
+	c := &Client{
+		Certs: &blockingCertSource{
+			map[string]*fakeCerts{
+				instance: b,
+			}},
+		Dialer: func(string, string) (net.Conn, error) {
+			return nil, nil
+		},
+	}
+
+	shutdown := make(chan bool, 1)
+	go func() {
+		c.Shutdown(1)
+		shutdown <- true
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	if !<-shutdown {
+		t.Errorf("shutdown should have completed quickly because there are no active connections")
+	}
+
+}


### PR DESCRIPTION
This PR supersedes #178 and takes in to account (most) of @hfwang's comments. By default, the proxy will automatically terminate when receiving a TERM signal (just like it currently does). People can also specify a timeout (`-term_timeout=30s`) to let the proxy wait for up to a certain amount of time before exiting.

If there are no active connections, the proxy will exit early (with a status code of 0). If it waits for the entire timeout period and there are still active connections, it will exit with a status code of 2. I picked 2 because I was seeing exit codes of 2 with the existing version but that could be because I have 2 open connections per proxy.