### PR TITLE
Terminate gracefully after receiving a SIGTERM signal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ download the associated JSON file, and set `-credential_file` to the path of the
 JSON file. You can also set the GOOGLE_APPLICATION_CREDENTIALS environment variable
 instead of passing this flag.
 
+The `-termination_grace_period` flag may be used to control the amount of time
+that the process will continue to run after receiving a SIGTERM signal. The default
+period is '20s'. During the termination period the proxy will refuse new
+connections. This is useful for rolling updates so that the proxy does not terminate
+until in-progress database operations have had time to finish. The argument must be
+specified as a number and a time unit - e.g. '10s' or '500ms'.
+
 ## Example invocations:
 
     ./cloud_sql_proxy -dir=/cloudsql -instances=my-project:us-central1:sql-inst &

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -53,6 +53,7 @@ var (
 	logDebugStdout = flag.Bool("log_debug_stdout", false, "If true, log messages that are not errors will output to stdout instead of stderr")
 
 	refreshCfgThrottle = flag.Duration("refresh_config_throttle", proxy.DefaultRefreshCfgThrottle, "If set, this flag specifies the amount of forced sleep between successive API calls in order to protect client API quota. Minimum allowed value is "+minimumRefreshCfgThrottle.String())
+	terminationGracePeriod = flag.Duration("termination_grace_period", proxy.DefaultTerminationGracePeriod, "If set, this flag specifies the amount of sleep between receiving a SIGTERM signal and terminating the process. Otherwise a default of 20s is used.")
 	checkRegion        = flag.Bool("check_region", false, `If specified, the 'region' portion of the connection string is required for
 Unix socket-based connections.`)
 
@@ -488,6 +489,7 @@ func main() {
 	if refreshCfgThrottle < minimumRefreshCfgThrottle {
 		refreshCfgThrottle = minimumRefreshCfgThrottle
 	}
+	terminationGracePeriod := *terminationGracePeriod
 	logging.Infof("Ready for new connections")
 
 	(&proxy.Client{
@@ -501,5 +503,6 @@ func main() {
 		}),
 		Conns:              connset,
 		RefreshCfgThrottle: refreshCfgThrottle,
+		TerminationGracePeriod: terminationGracePeriod,
 	}).Run(connSrc)
 }


### PR DESCRIPTION
See #128 

Added a SIGTERM handler to the client with a configurable termination grace period (default 20s). During this period the client will refuse new connections. At the end of the period the process will exit. This allows in-flight database operations to complete when running as a sidecar container in Kubernetes and performing rolling updates.