### PR TITLE
Validate gcloud auth before checking GCE scope

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -241,7 +241,7 @@ func checkFlags(onGCE bool) error {
 		return nil
 	}
 
-	// Check if the gcloud credentials are available.
+	// Check if gcloud credentials are available and if so, skip checking the GCE VM service account scope.
 	_, err := util.GcloudConfig()
 	if err == nil {
 		return nil

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -241,6 +241,12 @@ func checkFlags(onGCE bool) error {
 		return nil
 	}
 
+	// Check if the gcloud credentials are available.
+	_, err := util.GcloudConfig()
+	if err == nil {
+		return nil
+	}
+
 	scopes, err := metadata.Scopes("default")
 	if err != nil {
 		if _, ok := err.(metadata.NotDefinedError); ok {


### PR DESCRIPTION
 - When running cloud_sql_proxy in GCE instance that is configured with gcloud, cloud_sql_proxy fails saying:

the default Compute Engine service account is not configured with sufficient permissions to access the Cloud SQL API from this VM. Please create a new VM with Cloud SQL access (scope) enabled under "Identity and API access". Alternatively, create a new "service account key" and specify it using the -credential_file parameter

This happens because the auth check function doesn't check if gcloud auth is available.

Fix: Add additional gcloud check before checking for GCE metadata scopes.