### PR TITLE
Don't wait as long when calling onGCE and metadata server is unavailable

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -197,9 +197,9 @@ var defaultTmp = filepath.Join(os.TempDir(), "cloudsql-proxy-tmp")
 
 // See https://github.com/GoogleCloudPlatform/gcloud-golang/issues/194
 func onGCE() bool {
-    var netClient = &http.Client{
-        Timeout: time.Second * 2,
-    }
+	var netClient = &http.Client{
+		Timeout: time.Second * 2,
+	}
 	res, err := netClient.Get("http://metadata.google.internal")
 	if err != nil {
 		return false

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -195,18 +195,6 @@ Information for all flags:
 
 var defaultTmp = filepath.Join(os.TempDir(), "cloudsql-proxy-tmp")
 
-// See https://github.com/GoogleCloudPlatform/gcloud-golang/issues/194
-func onGCE() bool {
-	var netClient = &http.Client{
-		Timeout: time.Second * 2,
-	}
-	res, err := netClient.Get("http://metadata.google.internal")
-	if err != nil {
-		return false
-	}
-	return res.Header.Get("Metadata-Flavor") == "Google"
-}
-
 const defaultVersionString = "NO_VERSION_SET"
 
 var versionString = defaultVersionString
@@ -441,7 +429,7 @@ func main() {
 		}
 	}
 
-	onGCE := onGCE()
+	onGCE := metadata.OnGCE()
 	if err := checkFlags(onGCE); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -197,7 +197,10 @@ var defaultTmp = filepath.Join(os.TempDir(), "cloudsql-proxy-tmp")
 
 // See https://github.com/GoogleCloudPlatform/gcloud-golang/issues/194
 func onGCE() bool {
-	res, err := http.Get("http://metadata.google.internal")
+    var netClient = &http.Client{
+        Timeout: time.Second * 2,
+    }
+	res, err := netClient.Get("http://metadata.google.internal")
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Hello

In situations when outgoing traffic comes through a firewall (or network policy) and there is no rule allowing to make HTTP requests to any IP, `cloud_sql_proxy` will wait on start 30 seconds before it starts to listen TCP socket and accept connections. These 30 seconds it's trying to GET `http://metadata.google.internal`. So you need to increase `initialDelaySeconds` for readiness and liveness probes for `cloud_sql_proxy` sidecar and main containers both. This increases deploy time, timeouts etc. 

I think we need to override default timeout and if GET request doesn't succeed in 2 seconds,the function `onGCE()` returns `false` and we continue boot process.

Another possible solution is to add logging of this error. I spent a few hours to understand why our cloud_sql_proxy start so slowly and there weren't any helpful log messages.

Below you can see a 30 seconds gap if I have a route to this Google's IP and my outgoing packets are dropped:
```
17:15 n.shalnov:~/gcp$ cloud_sql_proxy -instances=project:us-east4:pg-rc=tcp:5432
2018/11/22 17:15:05 current FDs rlimit set to 1048576, wanted limit is 8500. Nothing to do here.
2018/11/22 17:15:35 Listening on 127.0.0.1:5432 for project:us-east4:pg-rc
2018/11/22 17:15:35 Ready for new connections
```