### PR TITLE
Treat GOOGLE_APPLICATION_CREDENTIALS env the same as credential file flag

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -263,7 +263,11 @@ func checkFlags(onGCE bool) error {
 }
 
 func authenticatedClient(ctx context.Context) (*http.Client, error) {
-	if f := *tokenFile; f != "" {
+	f := *tokenFile
+	if f == "" {
+		f = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	}
+	if f != "" {
 		all, err := ioutil.ReadFile(f)
 		if err != nil {
 			return nil, fmt.Errorf("invalid json file %q: %v", f, err)


### PR DESCRIPTION
This changes it so the relative priority of token sources is:

--credential_file flag
GOOGLE_APPLICATION_CREDENTIALS environment variable
--token flag
gcloud auth
FindDefaultCredentials (see https://github.com/golang/oauth2/blob/28207608b83849a028d4f12e46533a6b6894ecaf/google/default.go#L61-L76)

The previous change had inserted gcloud auth before FindDefaultCredentials, which resulted in gcloud auth overriding GOOGLE_APPLICATION_CREDENTIALS. After this change, GOOGLE_APPLICATION_CREDENTIALS still overrides the --token, however documentation states that the environment variable and the flag are interchangeable and that seems to be the order people are expecting.