### PR TITLE
docs: update k8s deployment sample to explain about graceful shutdown

### DIFF
--- a/Kubernetes.md
+++ b/Kubernetes.md
@@ -78,6 +78,15 @@ spec:
         - -dir=/cloudsql
         - -instances=project:database1=tcp:0.0.0.0:3306,project:database2=tcp:0.0.0.0:3307
         - -credential_file=/credentials/credentials.json
+        # set term_timeout if require graceful handling of shutdown
+        # NOTE: proxy will stop accepting new connections; only wait on existing connections
+        - term_timeout=10s
+        lifecycle:
+          preStop:
+            exec:
+              # (optional) add a preStop hook so that termination is delayed
+              # this is required if your server still require new connections (e.g., connection pools)
+              command: ['sleep', '10']
         ports:
         - name: port-database1
           containerPort: 3306


### PR DESCRIPTION
#### notes

we found out that the cloudSQL proxy stops accepting new connections upon SIGTERM.

while the addition of `term_timeout` flag helps to terminate gracefully on existing connections, this becomes a problem when a dependent container (a web server, in most cases) connecting to the proxy requires new connections at that point.

our workaround was to make user of k8s's lifecycle hook (preStop) to delay the termination while the web server can finish up existing HTTP requests (which requires DB querying over connection pools).

I thought it may be useful to add some notes here about it 🙇 