### PR TITLE
Allow to set the socket name per instance configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cloud_sql_proxy takes a few arguments to configure what instances to connect to 
   optional `-fuse_tmp` flag can specify where to place temporary files. The
   directory indicated by `-dir` is mounted.
 * `-instances="project1:region:instance1,project3:region:instance1"`: A comma-separated list
-  of instances to open inside `-dir`. Also supports exposing a tcp port instead of using Unix Domain Sockets; see examples below.
+  of instances to open inside `-dir`. Also supports exposing a tcp port and renaming the default Unix Domain Sockets; see examples below.
   Same list can be provided via INSTANCES environment variable, in case when both are provided - proxy will use command line flag.
 * `-instances_metadata=metadata_key`: Usable on [GCE](https://cloud.google.com/compute/docs/quickstart) only. The given [GCE metadata](https://cloud.google.com/compute/docs/metadata) key will be
   polled for a list of instances to open in `-dir`. The metadata key is relative from `computeMetadata/v1/`. The format for the value is the same as the 'instances' flag. A hanging-poll strategy is used, meaning that changes to
@@ -80,6 +80,14 @@ instead of passing this flag.
 
     # For programs which do not support using Unix Domain Sockets, specify tcp:
     ./cloud_sql_proxy -dir=/cloudsql -instances=my-project:us-central1:sql-inst=tcp:3306 &
+    mysql -u root -h 127.0.0.1
+
+    # For programs which require a certain Unix Domain Socket name:
+    ./cloud_sql_proxy -dir=/cloudsql -instances=my-project:us-central1:sql-inst=unix:custom_socket_name&
+    mysql -u root -h 127.0.0.1
+
+    # For programs which require a the Unix Domain Socket at a specific location, set an absolute path (overrides -dir):
+    ./cloud_sql_proxy -dir=/cloudsql -instances=my-project:us-central1:sql-inst=unix:/my/custom/sql-socket&
     mysql -u root -h 127.0.0.1
 
 ## To use inside a Go program:

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -149,6 +149,18 @@ Connection:
 
      When connecting over TCP, the -instances parameter is required.
 
+    To set a custom socket name, you can specify it as part of the instance
+	string.  The following example opens a unix socket in the directory
+	specified by -dir, which will be proxied to connect to the instance
+    'my-instance' in project 'my-project':
+
+            -instances=my-project:my-region:my-instance=unix:custom-socket-name
+
+	To override the -dir parameter, specify an absolute path as shown in the
+	following example:
+
+            -instances=my-project:my-region:my-instance=unix:/my/custom/sql-socket
+
      Supplying INSTANCES environment variable achieves the same effect.  One can
      use that to keep k8s manifest files constant across multiple environments
 

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -233,11 +233,19 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 			// No "host" part of the address. Be safe and assume that they want a
 			// loopback address.
 			ret.Network = spl[0]
-			addr, ok := loopbackForNet[spl[0]]
-			if !ok {
-				return ret, fmt.Errorf("invalid %q: unrecognized network %v", instance, spl[0])
+			if spl[0] == "unix" {
+				if strings.HasPrefix(spl[1], "/") {
+					ret.Address = spl[1]
+				} else {
+					ret.Address = filepath.Join(dir, spl[1])
+				}
+			} else {
+				addr, ok := loopbackForNet[spl[0]]
+				if !ok {
+					return ret, fmt.Errorf("invalid %q: unrecognized network %v", instance, spl[0])
+				}
+				ret.Address = fmt.Sprintf("%s:%s", addr, spl[1])
 			}
-			ret.Address = fmt.Sprintf("%s:%s", addr, spl[1])
 		case 3:
 			// User provided a host and port; use that.
 			ret.Network = spl[0]

--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -112,6 +112,14 @@ func TestParseInstanceConfig(t *testing.T) {
 			instanceConfig{"my-proj:my-reg:my-instance", "unix", "/x/my-proj:my-reg:my-instance"},
 			false, false,
 		}, {
+			"/x", "my-proj:my-reg:my-instance=unix:socket_name",
+			instanceConfig{"my-proj:my-reg:my-instance", "unix", "/x/socket_name"},
+			false, false,
+		}, {
+			"/x", "my-proj:my-reg:my-instance=unix:/my/custom/sql-socket",
+			instanceConfig{"my-proj:my-reg:my-instance", "unix", "/my/custom/sql-socket"},
+			false, false,
+		}, {
 			"/x", "my-proj:my-reg:my-instance=tcp:1234",
 			instanceConfig{"my-proj:my-reg:my-instance", "tcp", "[::1]:1234"},
 			false, true,


### PR DESCRIPTION
This pull requests allows to set a custom socket name for each instance.
Example: -instances=my-project:us-central1:sql-inst=unix:custom_socket_name

This pull request also allows to override `-dir` by specifying an absolute path. This would come in handy for me but I can easily remove it from this pull request if it's not desired for some reason.

Resolves: #241