### PR TITLE
Proxy rejects requests for first generation instances.

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -264,6 +264,10 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 		if err != nil {
 			return instanceConfig{}, err
 		}
+		if in.BackendType == "FIRST_GEN" {
+			logging.Errorf("WARNING: proxy client does not support first generation Cloud SQL instances.")
+			return instanceConfig{}, fmt.Errorf("%q is a first generation instance", instance)
+		}
 		if strings.HasPrefix(strings.ToLower(in.DatabaseVersion), "postgres") {
 			path := filepath.Join(dir, instance)
 			if err := os.MkdirAll(path, 0755); err != nil {

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -259,6 +259,10 @@ func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr
 	if len(data.IpAddresses) == 0 {
 		return nil, "", "", fmt.Errorf("no IP address found for %v", instance)
 	}
+	if data.BackendType == "FIRST_GEN" {
+		logging.Errorf("WARNING: proxy client does not support first generation Cloud SQL instances.")
+		return nil, "", "", fmt.Errorf("%q is a first generation instance", instance)
+	}
 
 	// Find the first matching IP address by user input IP address types
 	ipAddrInUse := ""


### PR DESCRIPTION
First generation instances are not supported by the proxy, so this causes connections to them to fail slightly faster (otherwise we need to wait for the connection to timeout!)