### PR TITLE
Added the error handling of the incorrect host flag setting

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -414,6 +414,12 @@ func main() {
 		}
 	}
 
+	if !strings.HasSuffix(*host, "/") {
+		logging.Errorf("Flag host should always end with /")
+		flag.PrintDefaults()
+		return
+	}
+
 	// TODO: needs a better place for consolidation
 	// if instances is blank and env var INSTANCES is supplied use it
 	if envInstances := os.Getenv("INSTANCES"); *instances == "" && envInstances != "" {


### PR DESCRIPTION
For the flag "host", the value should always end with '/'.