### PR TITLE
Add -remote_host_override for connecting to proxied instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ cloud_sql_proxy takes a few arguments to configure what instances to connect to 
   IP. Defaults to `PUBLIC,PRIVATE`
 * `-term_timeout=30s`: How long to wait for connections to close before shutting
   down the proxy. Defaults to 0.
+* `-remote_host_override=localhost:3307`: Override the API-supplied IP address for the CloudSQL server and instead connect to the supplied hostname:port. This can be useful when the CloudSQL server has a private IP only, and you are connecting from outside the VPC using SSH port forwarding. Defaults to API supplied IP address.
 
 Note: `-instances` and `-instances_metadata` may be used at the same time but
 are not compatible with the `-fuse` flag.

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -87,6 +87,9 @@ can be removed automatically by this program.`)
 You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same effect.`)
 	ipAddressTypes = flag.String("ip_address_types", "PUBLIC,PRIVATE", "Default to be 'PUBLIC,PRIVATE'. Options: a list of strings separated by ',', e.g. 'PUBLIC,PRIVATE' ")
 
+	// Setting to override the SQL server IP supplied by the API
+	remoteHostOverride = flag.String("remote_host_override", "", "An optional host:port combination to override the Cloud API supplied IP address. Useful when SQL server has a private IP only that must be port-forwarded or otherwise proxied.")
+
 	// Setting to choose what API to connect to
 	host = flag.String("host", "https://www.googleapis.com/sql/v1beta4/", "When set, the proxy uses this host as the base API path.")
 )
@@ -519,6 +522,7 @@ func main() {
 		}),
 		Conns:              connset,
 		RefreshCfgThrottle: refreshCfgThrottle,
+		RemoteHostOverride: remoteHostOverride,
 	}
 
 	signals := make(chan os.Signal, 1)

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -94,6 +94,11 @@ type Client struct {
 
 	// ConnectionsCounter is used to enforce the optional maxConnections limit
 	ConnectionsCounter uint64
+
+	// RemoteHostOverride overrides the GCP-supplied IP:port combination. Used
+	// when the SQL server has a private IP only, which must be forwarded via a
+	// tunnel.
+	RemoteHostOverride *string
 }
 
 type cacheEntry struct {
@@ -297,6 +302,10 @@ func (c *Client) tryConnect(addr string, cfg *tls.Config) (net.Conn, error) {
 	d := c.Dialer
 	if d == nil {
 		d = net.Dial
+	}
+	if c.RemoteHostOverride != nil {
+		addr = *c.RemoteHostOverride
+		logging.Verbosef("Overriding hostname with: %s", addr)
 	}
 	conn, err := d("tcp", addr)
 	if err != nil {


### PR DESCRIPTION
We have a CloudSQL DB with only a Private IP and a requirement to connect through the proxy only (for audit). When DBAs connect to this DB from their workstation (outside of the VPC), they must port-forward 3307 to their local machine over SSH as the private IP is not directly accessible. This flag allows them to tell the cloud_sql_proxy what `host:port` the CloudSQL server is on.