### PR TITLE
Release v1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM golang:1 as build
 
-ARG VERSION="1.15-develop"
+ARG VERSION="1.15"
 
 WORKDIR /go/src/cloudsql-proxy
 COPY . .


### PR DESCRIPTION
## Release Notes
* Added feature to specify per instance custom socket path  (#289)
* Updated default dialer IP type to "PUBLIC,PRIVATE" (#294)
* Updated Dockerfile for building proxy images. (#296)
* Added gcr.io mirrors in other regions (`us`, `eu`, and `asia`) (#295)
* Add `InitWithClient` and deprecate `InitClient` to prevent a mutex copy. (#273)

