### PR TITLE
Bubble err up on fail to parse instance configs instead of ignoring

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -334,7 +334,7 @@ func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instanc
 
 	cfgs, err := parseInstanceConfigs(dir, instances, cl)
 	if err != nil {
-		logging.Errorf("%v", err)
+		return nil, err
 	}
 
 	if dir == "" {


### PR DESCRIPTION
Fixes #288 

This change causes the program to exit on error during initial startup. This will prevent the container from entering a bad state on startup after a failed authentication, network error etc.