### PR TITLE
Return errors, and avoid bad updates

### DIFF
--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -336,7 +336,6 @@ func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instanc
 
 	cfgs, err := parseInstanceConfigs(dir, instances, cl)
 	if err != nil {
-		logging.Errorf("%v", err)
 		// Error when unable to correctly parse the instance configuration
 		return nil, err
 	}

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -66,6 +66,8 @@ func watchInstancesLoop(dir string, dst chan<- proxy.Conn, updates <-chan string
 		list, err := parseInstanceConfigs(dir, strings.Split(instances, ","), cl)
 		if err != nil {
 			logging.Errorf("%v", err)
+			// If we do not have a valid list of instances, skip this update
+			continue
 		}
 
 		stillOpen := make(map[string]net.Listener)

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -334,6 +334,8 @@ func CreateInstanceConfigs(dir string, useFuse bool, instances []string, instanc
 
 	cfgs, err := parseInstanceConfigs(dir, instances, cl)
 	if err != nil {
+		logging.Errorf("%v", err)
+		// Error when unable to correctly parse the instance configuration
 		return nil, err
 	}
 


### PR DESCRIPTION
If an error is hit while parsing instance configurations, this error should bubble up.

Also, while watching instances, if the instance configs error, we should assume the instance list is bad, and not process the result.