### PR TITLE
Prepare for release v.1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM golang:1 as build
 
-ARG VERSION="1.16"
+ARG VERSION="1.17-dev"
 
 WORKDIR /go/src/cloudsql-proxy
 COPY . .


### PR DESCRIPTION
Set the version in the Dockerfile to `1.17-dev` for using the prerelease versions.