### PR TITLE
Improve Dockerfile security.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ RUN go get ./...
 RUN go build -ldflags "-X 'main.versionString=$VERSION'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final Stage
-FROM gcr.io/distroless/base
-COPY --from=build /go/src/cloudsql-proxy/cloud_sql_proxy /cloud_sql_proxy
+FROM gcr.io/distroless/base-debian10:nonroot
+COPY --from=build --chown=nonroot /go/src/cloudsql-proxy/cloud_sql_proxy /cloud_sql_proxy
+USER nonroot


### PR DESCRIPTION
Updates base image to `distroless/base-debian10:nonroot` and runs as a non root user.

Fixes #320. 