### PR TITLE
fix: Remove incorrect api base url from the host flag.

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -88,7 +88,7 @@ You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same
 	ipAddressTypes = flag.String("ip_address_types", "PUBLIC,PRIVATE", "Default to be 'PUBLIC,PRIVATE'. Options: a list of strings separated by ',', e.g. 'PUBLIC,PRIVATE' ")
 
 	// Setting to choose what API to connect to
-	host = flag.String("host", "https://www.googleapis.com/sql/v1beta4/", "When set, the proxy uses this host as the base API path.")
+	host = flag.String("host", "", "When set, the proxy uses this host as the base API path.")
 )
 
 const (
@@ -331,6 +331,9 @@ func listInstances(ctx context.Context, cl *http.Client, projects []string) ([]s
 	if err != nil {
 		return nil, err
 	}
+	if *host != "" {
+		sql.BasePath = *host
+	}
 
 	ch := make(chan string)
 	var wg sync.WaitGroup
@@ -426,7 +429,7 @@ func main() {
 		}
 	}
 
-	if !strings.HasSuffix(*host, "/") {
+	if *host != "" && !strings.HasSuffix(*host, "/") {
 		logging.Errorf("Flag host should always end with /")
 		flag.PrintDefaults()
 		return

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -88,7 +88,7 @@ You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same
 	ipAddressTypes = flag.String("ip_address_types", "PUBLIC,PRIVATE", "Default to be 'PUBLIC,PRIVATE'. Options: a list of strings separated by ',', e.g. 'PUBLIC,PRIVATE' ")
 
 	// Setting to choose what API to connect to
-	host = flag.String("host", "", "When set, the proxy uses this host as the base API path.")
+	host = flag.String("host", "", "When set, the proxy uses this host as the base API path. Example: https://sqladmin.googleapis.com")
 )
 
 const (

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -264,7 +264,9 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 	if err != nil {
 		return instanceConfig{}, err
 	}
-	sql.BasePath = *host
+	if *host != "" {
+		sql.BasePath = *host
+	}
 	inst, err := sql.Instances.Get(proj, name).Do()
 	if err != nil {
 		return instanceConfig{}, err


### PR DESCRIPTION
Fixes #331.

Also address a couple of instances where the base url was not applied. 

Note: I considered updating from `New` to `NewClient` since the former is deprecated, but decided that it requires larger restructuring. 

