### PR TITLE
fix: Prevent the binary from getting checked in when using go build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 # Jetbrains IDE
 .idea/
 
+# Binary output
+cmd/cloud_sql_proxy/cloud_sql_proxy
+
 tests/cloud_sql_proxy

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@
 # Jetbrains IDE
 .idea/
 
-# Binary output
-cmd/cloud_sql_proxy/cloud_sql_proxy
-
-tests/cloud_sql_proxy
+# Compiled binary
+*/cloud_sql_proxy

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 .idea/
 
 # Compiled binary
-*/cloud_sql_proxy
+cmd/cloud_sql_proxy/cloud_sql_proxy
+
+# Compiled during tests
+tests/cloud_sql_proxy


### PR DESCRIPTION
## Change Description

I've almost checked the binary a few times in; is there a reason we need to have this in the repo? 

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  Small change; can open an issue if there's enough of a reason to
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)