### PR TITLE
Release 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM golang:1 as build
 
-ARG VERSION="1.17-dev"
+ARG VERSION="1.17"
 
 WORKDIR /go/src/cloudsql-proxy
 COPY . .


### PR DESCRIPTION
## Release Notes

* Updated base image for `gcr.io/cloudsql-docker` to `gcr.io/distroless/base-debian10:nonroot`
* Fix compatibility with `google.golang.org/api v0.15.0` or higher
* Added `-skip_failed_instance_config`: Setting this flag will allow you to prevent the proxy from terminating when some instance configurations could not be parsed and/or are unavailable.
* Update to dial database connections using [`proxy.FromEnvironment`](https://godoc.org/golang.org/x/net/http/httpproxy#FromEnvironment). This enables support for proxies such as SOCKS5.

