### PR TITLE
Print out any errors during SIGTERM-caused shutdown

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -547,11 +547,10 @@ func main() {
 		logging.Infof("Received TERM signal. Waiting up to %s before terminating.", *termTimeout)
 
 		err := proxyClient.Shutdown(*termTimeout)
-
 		if err == nil {
 			os.Exit(0)
 		}
-		os.Exit(2)
+		log.Fatalf("Error during SIGTERM shutdown: %v", err)
 	}()
 
 	proxyClient.Run(connSrc)

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -550,7 +550,8 @@ func main() {
 		if err == nil {
 			os.Exit(0)
 		}
-		log.Fatalf("Error during SIGTERM shutdown: %v", err)
+		logging.Errorf("Error during SIGTERM shutdown: %v", err)
+		os.Exit(2)
 	}()
 
 	proxyClient.Run(connSrc)


### PR DESCRIPTION
Before this change any error encountered during a forced shutdown via proxyClient.Shutdown will not be printed out, yet when there is an error the Proxy will still exit with a nonzero status. In addition to exiting with a nonzero status, this CL causes the errors to actually be printed out.

Note that log.Fatal(f) exits the program with exit code 1, which is a change from the prior implementation which exited with code 2. Let me know if exit code 2 was particularly important; I will happily log a message and explicitly exit(2).

I noticed this upon reading issue https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/388.