### PR TITLE
Sleep more than a nanosecond during SIGTERM shutdown

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -361,7 +361,7 @@ func NewConnSrc(instance string, l net.Listener) <-chan Conn {
 func (c *Client) Shutdown(termTimeout time.Duration) error {
 	termTime := time.Now().Add(termTimeout)
 	for termTime.After(time.Now()) && atomic.LoadUint64(&c.ConnectionsCounter) > 0 {
-		time.Sleep(1)
+		time.Sleep(time.Second)
 	}
 
 	active := atomic.LoadUint64(&c.ConnectionsCounter)


### PR DESCRIPTION
`time.Sleep(1)` is equivalent to `time.Sleep(time.Nanosecond)` (because `time.Nanosecond==1`*). I am only guessing that "1 second" was the intended sleep interval (though it seems appropriate). Feel free to suggest a different duration.

* https://golang.org/pkg/time/#Nanosecond