### PR TITLE
Optimize term-timeout wait.

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -359,14 +359,15 @@ func NewConnSrc(instance string, l net.Listener) <-chan Conn {
 // close. Returns an error if there are still active connections after waiting
 // for the whole length of the timeout.
 func (c *Client) Shutdown(termTimeout time.Duration) error {
-	term, tick := time.After(termTimeout), time.Tick(100 * time.Millisecond)
+	term, ticker := time.After(termTimeout), time.NewTicker(100*time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
-			case <- tick:
-				if atomic.LoadUint64(&c.ConnectionsCounter) > 0 {
-					continue
-				}
-			case <- term:
+		case <-ticker.C:
+			if atomic.LoadUint64(&c.ConnectionsCounter) > 0 {
+				continue
+			}
+		case <-term:
 		}
 		break
 	}


### PR DESCRIPTION
Add a small optimization to better cap the max amount of time the proxy spends waiting for incoming connections to close. 

/cc @Carrotman42 