### PR TITLE
fix(container): Specify nonroot user by uid to work with runAsNonRoot.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ RUN go build -ldflags "-X 'main.versionString=$VERSION'" -o cloud_sql_proxy ./cm
 # Final Stage
 FROM gcr.io/distroless/base-debian10:nonroot
 COPY --from=build --chown=nonroot /go/src/cloudsql-proxy/cloud_sql_proxy /cloud_sql_proxy
-USER nonroot
+# use the uid for the nonroot user for compatibility with runAsNonRoot
+USER 65532

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -176,7 +176,7 @@ as a separate service for several reasons:
   scales
    
 1. Add the Cloud SQL proxy to the pod configuration under `containers:` :
-    > [proxy_with_workload-identity.yaml](proxy_with_workload_identity.yaml#L33-L50)
+    > [proxy_with_workload-identity.yaml](proxy_with_workload_identity.yaml#L33-L549)
     ```yaml
     - name: cloud-sql-proxy
     # It is recommended to use the latest version of the Cloud SQL proxy
@@ -193,8 +193,8 @@ as a separate service for several reasons:
       # Defaults: MySQL: 3306, Postgres: 5432, SQLServer: 1433
       - "-instances=<INSTANCE_CONNECTION_NAME>=tcp:<DB_PORT>"
     securityContext:
-      # The default Cloud SQL proxy image is based on distroless, which
-      # runs as the "nonroot" user (uid: 65534) by default.
+      # The default Cloud SQL proxy image runs as the
+      # "nonroot" user and group (uid: 65532) by default.
       runAsNonRoot: true
     ```
    If you are using a service account key, specify your secret volume and add
@@ -205,8 +205,8 @@ as a separate service for several reasons:
       # This flag specifies where the service account key can be found
       - "-credential_file=/secrets/service_account.json"
     securityContext:
-      # The default Cloud SQL proxy image is based on distroless, which
-      # runs as the "nonroot" user (uid: 65534) by default.
+      # The default Cloud SQL proxy image runs as the
+      # "nonroot" user and group (uid: 65532) by default.
       runAsNonRoot: true
     volumeMounts:
     - name: <YOUR-SA-SECRET-VOLUME>

--- a/examples/kubernetes/no_proxy_private_ip.yaml
+++ b/examples/kubernetes/no_proxy_private_ip.yaml
@@ -55,8 +55,8 @@ spec:
         # This flag specifies where the service account key can be found
         - "-credential_file=/secrets/service_account.json"
         securityContext:
-          # The default Cloud SQL proxy image is based on distroless, which
-          # runs as the "nonroot" user (uid: 65534) by default.
+          # The default Cloud SQL proxy image runs as the
+          # "nonroot" user and group (uid: 65532) by default.
           runAsNonRoot: true
         volumeMounts:
         - name: <YOUR-SA-SECRET-VOLUME>

--- a/examples/kubernetes/proxy_with_sa_key.yaml
+++ b/examples/kubernetes/proxy_with_sa_key.yaml
@@ -49,8 +49,8 @@ spec:
           # This flag specifies where the service account key can be found
           - "-credential_file=/secrets/service_account.json"
         securityContext:
-          # The default Cloud SQL proxy image is based on distroless, which
-          # runs as the "nonroot" user (uid: 65534) by default.
+          # The default Cloud SQL proxy image runs as the
+          # "nonroot" user and group (uid: 65532) by default.
           runAsNonRoot: true
         volumeMounts:
         - name: <YOUR-SA-SECRET-VOLUME>

--- a/examples/kubernetes/proxy_with_workload_identity.yaml
+++ b/examples/kubernetes/proxy_with_workload_identity.yaml
@@ -51,7 +51,7 @@ spec:
           # Defaults: MySQL: 3306, Postgres: 5432, SQLServer: 1433
           - "-instances=<INSTANCE_CONNECTION_NAME>=tcp:<DB_PORT>"
         securityContext:
-          # The default Cloud SQL proxy image is based on distroless, which
-          # runs as the "nonroot" user (uid: 65534) by default.
+          # The default Cloud SQL proxy image runs as the
+          # "nonroot" user and group (uid: 65532) by default.
           runAsNonRoot: true
       # [END cloud_sql_proxy_k8s_container]


### PR DESCRIPTION
## Change Description
Specify nonroot user by uid to work with runAsNonRoot.

I've backported this fix to release v1.17 since it should be fully compatible. I will update the container tags once this is merged. 

## Relevant issues:

- Fixes #386 