### PR TITLE
Update Helm chart URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ __WARNING__: _These distributions are not officially supported by Google._
 
 ### K8s Cluster Service using Helm
 
-  Follow these [instructions](https://github.com/kubernetes/charts/tree/master/stable/gcloud-sqlproxy).
+  Follow these [instructions](https://github.com/rimusz/charts/tree/master/stable/gcloud-sqlproxy).
   This chart creates a Deployment and a Service, but we recommend deploying the proxy as a sidecar container in your pods.
 
 ### .Net Proxy Wrapper (Nuget Package)


### PR DESCRIPTION
💁 The previous repository was deprecated in favour of https://github.com/rimusz/charts some time ago. See https://github.com/helm/charts/pull/9219 for further context and information.