### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each image is tagged with the version of the proxy it was released with. The
 following tags are currently supported:
   * `v$VERSION` - default image (recommended)
   * `v$VERSION-alpine` - uses [`alpine:3`](https://hub.docker.com/_/alpine) as a base image
-  * `v$VERSION-buster` - uses [`debain:buster`](https://hub.docker.com/_/debian) as a base image
+  * `v$VERSION-buster` - uses [`debian:buster`](https://hub.docker.com/_/debian) as a base image
 
 __Note:__ We strongly recommend to always use the latest version of the proxy,
 and to update the version regularly. However, we recommend pinning to a


### PR DESCRIPTION
## Change Description

Change `debain` to `debian` in README.md
