### PR TITLE
fix: Add socket suffix for Postgres instances when running in `-fuse` mode

### DIFF
--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -253,10 +253,12 @@ func (r *fsRoot) Lookup(_ context.Context, req *fuse.LookupRequest, resp *fuse.L
 
 	// MySQL expects a Unix domain socket at the symlinked path whereas Postgres expects
 	// a socket named ".s.PGSQL.5432" in the directory given by the database path.
+	// Look up instance database version to determine the correct socket path.
+	// Client is nil in unit tests.
 	if r.client != nil {
 		version, err := r.client.InstanceVersion(instance)
 		if err != nil {
-			return nil, fuse.EIO
+			return nil, fuse.ENOENT
 		}
 		if strings.HasPrefix(strings.ToLower(version), "postgres") {
 			if err := os.MkdirAll(path, 0755); err != nil {

--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -41,6 +41,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,7 +65,7 @@ func Supported() bool {
 // error, the returned chan will be closed.
 //
 // The connset parameter is optional.
-func NewConnSrc(mountdir, tmpdir string, connset *proxy.ConnSet) (<-chan proxy.Conn, io.Closer, error) {
+func NewConnSrc(mountdir, tmpdir string, client *proxy.Client, connset *proxy.ConnSet) (<-chan proxy.Conn, io.Closer, error) {
 	if err := os.MkdirAll(tmpdir, 0777); err != nil {
 		return nil, nil, err
 	}
@@ -91,6 +92,7 @@ func NewConnSrc(mountdir, tmpdir string, connset *proxy.ConnSet) (<-chan proxy.C
 		links:   make(map[string]symlink),
 		closers: []io.Closer{c},
 		connset: connset,
+		client:  client,
 	}
 
 	server := fs.New(c, &fs.Config{
@@ -142,6 +144,7 @@ func (symlink) Attr(ctx context.Context, a *fuse.Attr) error {
 type fsRoot struct {
 	tmpDir, linkDir string
 
+	client  *proxy.Client
 	connset *proxy.ConnSet
 
 	// sockLock protects fields in this struct related to sockets; specifically
@@ -245,7 +248,24 @@ func (r *fsRoot) Lookup(_ context.Context, req *fuse.LookupRequest, resp *fuse.L
 	}
 
 	path := filepath.Join(r.tmpDir, instance)
-	os.Remove(path) // Best effort; the following will fail if this does.
+	os.RemoveAll(path) // Best effort; the following will fail if this does.
+	linkpath := path
+
+	// MySQL expects a Unix domain socket at the symlinked path whereas Postgres expects
+	// a socket named ".s.PGSQL.5432" in the directory given by the database path.
+	if r.client != nil {
+		version, err := r.client.InstanceVersion(instance)
+		if err != nil {
+			return nil, fuse.EIO
+		}
+		if strings.HasPrefix(strings.ToLower(version), "postgres") {
+			if err := os.MkdirAll(path, 0755); err != nil {
+				return nil, fuse.EIO
+			}
+			path = filepath.Join(linkpath, ".s.PGSQL.5432")
+		}
+	}
+
 	sock, err := net.Listen("unix", path)
 	if err != nil {
 		logging.Errorf("couldn't listen at %q: %v", path, err)
@@ -257,7 +277,7 @@ func (r *fsRoot) Lookup(_ context.Context, req *fuse.LookupRequest, resp *fuse.L
 
 	go r.listenerLifecycle(sock, instance, path)
 
-	ret := symlink(path)
+	ret := symlink(linkpath)
 	r.links[instance] = ret
 	// TODO(chowski): memory leak when listeners exit on their own via removeListener.
 	r.closers = append(r.closers, sock)

--- a/proxy/fuse/fuse_test.go
+++ b/proxy/fuse/fuse_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func TestFuseClose(t *testing.T) {
-	src, fuse, err := NewConnSrc(dir, tmpdir, nil)
+	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestFuseClose(t *testing.T) {
 
 // TestBadDir verifies that the fuse module does not create directories, only simple files.
 func TestBadDir(t *testing.T) {
-	_, fuse, err := NewConnSrc(dir, tmpdir, nil)
+	_, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestBadDir(t *testing.T) {
 }
 
 func TestReadme(t *testing.T) {
-	_, fuse, err := NewConnSrc(dir, tmpdir, nil)
+	_, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestReadme(t *testing.T) {
 }
 
 func TestSingleInstance(t *testing.T) {
-	src, fuse, err := NewConnSrc(dir, tmpdir, nil)
+	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestSingleInstance(t *testing.T) {
 }
 
 func BenchmarkNewConnection(b *testing.B) {
-	src, fuse, err := NewConnSrc(dir, tmpdir, nil)
+	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -53,7 +53,7 @@ type CertSource interface {
 	// provided instance.
 	Local(instance string) (tls.Certificate, error)
 	// Remote returns the instance's CA certificate, address, and name.
-	Remote(instance string) (cert *x509.Certificate, addr, name string, err error)
+	Remote(instance string) (cert *x509.Certificate, addr, name, version string, err error)
 }
 
 // Client is a type to handle connecting to a Server. All fields are required
@@ -100,9 +100,10 @@ type Client struct {
 type cacheEntry struct {
 	lastRefreshed time.Time
 	// If err is not nil, the addr and cfg are not valid.
-	err  error
-	addr string
-	cfg  *tls.Config
+	err     error
+	addr    string
+	version string
+	cfg     *tls.Config
 }
 
 // Run causes the client to start waiting for new connections to connSrc and
@@ -153,7 +154,7 @@ func (c *Client) handleConn(conn Conn) {
 // refreshCfg uses the CertSource inside the Client to find the instance's
 // address as well as construct a new tls.Config to connect to the instance. It
 // caches the result.
-func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, err error) {
+func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, version string, err error) {
 	c.refreshCfgL.Lock()
 	defer c.refreshCfgL.Unlock()
 
@@ -171,7 +172,7 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, err 
 	if oldok && time.Since(old.lastRefreshed) < throttle {
 		logging.Errorf("Throttling refreshCfg(%s): it was only called %v ago", instance, time.Since(old.lastRefreshed))
 		// Refresh was called too recently, just reuse the result.
-		return old.addr, old.cfg, old.err
+		return old.addr, old.cfg, old.version, old.err
 	}
 
 	defer func() {
@@ -180,6 +181,7 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, err 
 			lastRefreshed: time.Now(),
 			err:           err,
 			addr:          addr,
+			version:       version,
 			cfg:           cfg,
 		}
 		c.cacheL.Unlock()
@@ -187,12 +189,12 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, err 
 
 	mycert, err := c.Certs.Local(instance)
 	if err != nil {
-		return "", nil, err
+		return "", nil, "", err
 	}
 
-	scert, addr, name, err := c.Certs.Remote(instance)
+	scert, addr, name, version, err := c.Certs.Remote(instance)
 	if err != nil {
-		return "", nil, err
+		return "", nil, "", err
 	}
 	certs := x509.NewCertPool()
 	certs.AddCert(scert)
@@ -218,18 +220,18 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, err 
 	if timeToRefresh <= 0 {
 		err = fmt.Errorf("new ephemeral certificate expires too soon: current time: %v, certificate expires: %v", expire, now)
 		logging.Errorf("ephemeral certificate (%+v) error: %v", mycert, err)
-		return "", nil, err
+		return "", nil, "", err
 	}
 	go c.refreshCertAfter(instance, timeToRefresh)
 
-	return fmt.Sprintf("%s:%d", addr, c.Port), cfg, nil
+	return fmt.Sprintf("%s:%d", addr, c.Port), cfg, version, nil
 }
 
 // refreshCertAfter refreshes the epehemeral certificate of the instance after timeToRefresh.
 func (c *Client) refreshCertAfter(instance string, timeToRefresh time.Duration) {
 	<-time.After(timeToRefresh)
 	logging.Verbosef("ephemeral certificate for instance %s will expire soon, refreshing now.", instance)
-	if _, _, err := c.refreshCfg(instance); err != nil {
+	if _, _, _, err := c.refreshCfg(instance); err != nil {
 		logging.Errorf("failed to refresh the ephemeral certificate for %s before expiring: %v", instance, err)
 	}
 }
@@ -264,30 +266,30 @@ func isExpired(cfg *tls.Config) bool {
 	return time.Now().After(cfg.Certificates[0].Leaf.NotAfter)
 }
 
-func (c *Client) cachedCfg(instance string) (string, *tls.Config) {
+func (c *Client) cachedCfg(instance string) (string, *tls.Config, string) {
 	c.cacheL.RLock()
 	ret, ok := c.cfgCache[instance]
 	c.cacheL.RUnlock()
 
 	// Don't waste time returning an expired/invalid cert.
 	if !ok || ret.err != nil || isExpired(ret.cfg) {
-		return "", nil
+		return "", nil, ""
 	}
-	return ret.addr, ret.cfg
+	return ret.addr, ret.cfg, ret.version
 }
 
 // Dial uses the configuration stored in the client to connect to an instance.
 // If this func returns a nil error the connection is correctly authenticated
 // to connect to the instance.
 func (c *Client) Dial(instance string) (net.Conn, error) {
-	if addr, cfg := c.cachedCfg(instance); cfg != nil {
+	if addr, cfg, _ := c.cachedCfg(instance); cfg != nil {
 		ret, err := c.tryConnect(addr, cfg)
 		if err == nil {
 			return ret, err
 		}
 	}
 
-	addr, cfg, err := c.refreshCfg(instance)
+	addr, cfg, _, err := c.refreshCfg(instance)
 	if err != nil {
 		return nil, err
 	}
@@ -353,6 +355,18 @@ func NewConnSrc(instance string, l net.Listener) <-chan Conn {
 		}
 	}()
 	return ch
+}
+
+// InstanceVersion uses client cache to return instance version string.
+func (c *Client) InstanceVersion(instance string) (string, error) {
+	if _, cfg, version := c.cachedCfg(instance); cfg != nil {
+		return version, nil
+	}
+	_, _, version, err := c.refreshCfg(instance)
+	if err != nil {
+		return "", err
+	}
+	return version, nil
 }
 
 // Shutdown waits up to a given amount of time for all active connections to

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -60,8 +60,8 @@ func (cs *blockingCertSource) Local(instance string) (tls.Certificate, error) {
 	}, nil
 }
 
-func (cs *blockingCertSource) Remote(instance string) (cert *x509.Certificate, addr, name string, err error) {
-	return &x509.Certificate{}, "fake address", "fake name", nil
+func (cs *blockingCertSource) Remote(instance string) (cert *x509.Certificate, addr, name, version string, err error) {
+	return &x509.Certificate{}, "fake address", "fake name", "fake version", nil
 }
 
 func TestClientCache(t *testing.T) {


### PR DESCRIPTION
Fixes #207

PostgreSQL requires that the Unix domain socket be named ".s.PGSQL.5432". This logic is already present when using the `-instances` or `-projects` flags; however, it does not work when the proxy is running with `-fuse`.

With this change, I am now able to run CloudSQL proxy with `-fuse` and use `psql` to connect to the database:
```
$ INSTANCE=<project:location:name>
$ cloudsqlproxy -fuse -dir /tmp/fuse/cloudsql -fuse_tmp /tmp/fuse/tmp &
$ psql -h /tmp/fuse/cloudsql/$INSTANCE
Password:
```

To eliminate multiple instance.get calls, the implementation reuses the instance cache in the proxy client to also store database version. This is then used in` fuse.go` to create the appropriate directory structure. To accommodate this change, the fuse instance now takes a client pointer which required a change in the initialization order.
