### PR TITLE
docs: add documentation for log_debug_std flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cloud_sql_proxy takes a few arguments to configure what instances to connect to 
   down the proxy. Defaults to 0.
 * `-skip_failed_instance_config`: Setting this flag will allow you to prevent the proxy from terminating when
 	some instance configurations could not be parsed and/or are unavailable.
+* `-log_debug_stdout=true`: This is to log non-error output to stdOut instead of stdErr. For example, if you don't want connection related messages to log as errors, set this flag to true. Defaults to false.
 
 Note: `-instances` and `-instances_metadata` may be used at the same time but
 are not compatible with the `-fuse` flag.


### PR DESCRIPTION
## Change Description

The PR addresses the missing documentation issue while configuring cloud_sql_proxy.
Adding documentation for the flag log_debug_std

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #428