### PR TITLE
chore: add goModTidy to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   "prConcurrentLimit": 0,
   "rebaseStalePrs": true,
   "masterIssue": true,
-  "semanticCommits": true
+  "semanticCommits": true,
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
 }


### PR DESCRIPTION
## Change Description

renovate-bot PRs should run `go mod tidy`


