### PR TITLE
chore: Add support for metadata to version strings

### DIFF
--- a/.build/gcs_upload.yaml
+++ b/.build/gcs_upload.yaml
@@ -26,7 +26,7 @@ steps:
     entrypoint: "bash"
     args:
       - "-c"
-      - 'go build -ldflags "-X main.versionString=${_VERSION}" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
+      - 'go build -ldflags "-X main.versionString=${_VERSION} -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
   - id: linux.386
     name: "golang:1.14"
     env:
@@ -35,7 +35,7 @@ steps:
     entrypoint: "bash"
     args:
       - "-c"
-      - 'go build -ldflags "-X main.versionString=${_VERSION}" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
+      - 'go build -ldflags "-X main.versionString=${_VERSION} -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
   - id: darwin.amd64
     name: "golang:1.14"
     env:
@@ -44,7 +44,7 @@ steps:
     entrypoint: "bash"
     args:
       - "-c"
-      - 'go build -ldflags "-X main.versionString=${_VERSION}" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
+      - 'go build -ldflags "-X main.versionString=${_VERSION} -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
   - id: darwin.386
     name: "golang:1.14"
     env:
@@ -53,7 +53,7 @@ steps:
     entrypoint: "bash"
     args:
       - "-c"
-      - 'go build -ldflags "-X main.versionString=${_VERSION}" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
+      - 'go build -ldflags "-X main.versionString=${_VERSION}  -X main.metadataString=binary.$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
   - id: windows.amd64
     name: "golang:1.14"
     env:
@@ -62,7 +62,7 @@ steps:
     entrypoint: "bash"
     args:
       - "-c"
-      - 'go build -ldflags "-X main.versionString=${_VERSION}" -o cloud_sql_proxy_x64.exe ./cmd/cloud_sql_proxy'
+      - 'go build -ldflags "-X main.versionString=${_VERSION}  -X main.metadataString=binary.$$GOOS.$$GOARCH" -o cloud_sql_proxy_x64.exe ./cmd/cloud_sql_proxy'
   - id: windows.386
     name: "golang:1.14"
     env:
@@ -71,7 +71,7 @@ steps:
     entrypoint: "bash"
     args:
       - "-c"
-      - 'go build -ldflags "-X main.versionString=${_VERSION}" -o cloud_sql_proxy_x86.exe ./cmd/cloud_sql_proxy'
+      - 'go build -ldflags "-X main.versionString=${_VERSION}  -X main.metadataString=binary.$$GOOS.$$GOARCH" -o cloud_sql_proxy_x86.exe ./cmd/cloud_sql_proxy'
 artifacts:
   objects:
     location: "gs://cloudsql-proxy/v${_VERSION}/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X 'main.versionString=$VERSION'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X 'main.versionString=$VERSION' -X main.metadataString='container'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final Stage
 FROM gcr.io/distroless/base-debian10:nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X 'main.versionString=$VERSION' -X main.metadataString='container'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X main.versionString=$VERSION -X main.metadataString=container" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final Stage
 FROM gcr.io/distroless/base-debian10:nonroot

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -21,7 +21,7 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X 'main.versionString=$VERSION'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X 'main.versionString=$VERSION' -X main.metadataString='container.alpine'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM alpine:3

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -21,7 +21,7 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X 'main.versionString=$VERSION' -X main.metadataString='container.alpine'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X main.versionString=$VERSION -X main.metadataString=container.alpine" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM alpine:3

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -21,7 +21,7 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X 'main.versionString=$VERSION'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X 'main.versionString=$VERSION' -X main.metadataString='container.buster'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM debian:buster

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -21,7 +21,7 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X 'main.versionString=$VERSION' -X main.metadataString='container.buster'" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X main.versionString=$VERSION -X main.metadataString=container.buster" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM debian:buster

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -210,12 +210,13 @@ Information for all flags:
 
 var defaultTmp = filepath.Join(os.TempDir(), "cloudsql-proxy-tmp")
 
-// versionString indiciates the version of the proxy currently in use. 
+// versionString indiciates the version of the proxy currently in use.
 const versionString = "1.18.1-dev"
-// metadataString indiciates additional build or distribution metadata. 
+
+// metadataString indiciates additional build or distribution metadata.
 const metadataString = ""
 
-// semanticVersion returns the version of the proxy in a semver format. 
+// semanticVersion returns the version of the proxy in a semver format.
 func semanticVersion() string {
 	v := versionString
 	if metadataString != "" {

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -211,10 +211,10 @@ Information for all flags:
 var defaultTmp = filepath.Join(os.TempDir(), "cloudsql-proxy-tmp")
 
 // versionString indiciates the version of the proxy currently in use.
-const versionString = "1.18.1-dev"
+var versionString = "1.18.1-dev"
 
 // metadataString indiciates additional build or distribution metadata.
-const metadataString = ""
+var metadataString = ""
 
 // semanticVersion returns the version of the proxy in a semver format.
 func semanticVersion() string {

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -210,29 +210,23 @@ Information for all flags:
 
 var defaultTmp = filepath.Join(os.TempDir(), "cloudsql-proxy-tmp")
 
-const defaultVersionString = "NO_VERSION_SET"
+// versionString indiciates the version of the proxy currently in use. 
+const versionString = "1.18.1-dev"
+// metadataString indiciates additional build or distribution metadata. 
+const metadataString = ""
 
-var versionString = defaultVersionString
+// semanticVersion returns the version of the proxy in a semver format. 
+func semanticVersion() string {
+	v := versionString
+	if metadataString != "" {
+		v += "+" + metadataString
+	}
+	return v
+}
 
-// userAgentFromVersionString returns an appropriate user agent string for
-// identifying this proxy process, or a blank string if versionString was not
-// set to an interesting value.
+// userAgentFromVersionString returns an appropriate user agent string for identifying this proxy process.
 func userAgentFromVersionString() string {
-	if versionString == defaultVersionString {
-		return ""
-	}
-
-	// Example versionString (see build.sh):
-	//    version 1.05; sha 0f69d99588991aba0879df55f92562f7e79d7ca1 built Mon May  2 17:57:05 UTC 2016
-	//
-	// Remove the "version " text from versionString.
-	versionString = strings.Replace(versionString, "version ", "", 1)
-	// We just want the part before the semicolon.
-	semi := strings.IndexByte(versionString, ';')
-	if semi == -1 {
-		return ""
-	}
-	return "cloud_sql_proxy/" + versionString[:semi]
+	return "cloud_sql_proxy/" + semanticVersion()
 }
 
 const accountErrorSuffix = `Please create a new VM with Cloud SQL access (scope) enabled under "Identity and API access". Alternatively, create a new "service account key" and specify it using the -credential_file parameter`
@@ -407,7 +401,7 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Println("Cloud SQL Proxy:", versionString)
+		fmt.Println("Cloud SQL Proxy:", semanticVersion())
 		return
 	}
 


### PR DESCRIPTION
## Change Description

Adds support for semantic-version style metadata (`$version-prelease+metadata1.metadata2`) in version tags and fixes user agent to work with the new version format.