### PR TITLE
chore: Add a workflow to update the versionString on release PRs

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -1,0 +1,37 @@
+
+name: update-version
+on:
+  pull_request:
+          types: [opened]
+          branches: [master]
+
+jobs:
+  update-version-in-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          ref: ${{ github.head_ref }}
+
+      - if: github.actor == "release-please[bot]"
+        name: find-and-replace-version
+        run: |
+          VERSION=$(cat version.txt)
+          sed -i -r 's/[0-9]+.[0-9]+.[0-9]+(-dev)?/'"$VERSION"'/' cmd/cloud_sql_proxy/cloud_sql_proxy.go
+          
+      - if: github.actor == "release-please[bot]"
+        name: setup-git-config
+        run: |
+          git config user.name "release-please[bot]"
+          git config user.email "55107282+release-please[bot]@users.noreply.github.com"
+          
+      - if: github.actor == "release-please[bot]"
+        name: push-commit
+        run: |
+          git add cmd/cloud_sql_proxy/cloud_sql_proxy.go
+          git commit -m "Update version"
+          git push origin ${{ github.head_ref }}
+      
+
+        

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -2,8 +2,9 @@
 name: update-version
 on:
   pull_request:
-          types: [opened]
           branches: [master]
+          paths: 
+            - 'version.txt'
 
 jobs:
   update-version-in-pr:

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -20,16 +20,8 @@ jobs:
         run: |
           VERSION=$(cat version.txt)
           sed -i -r 's/(var versionString = ")[0-9]+.[0-9]+.[0-9]+(-dev)?/\1'"$VERSION"'/' cmd/cloud_sql_proxy/cloud_sql_proxy.go
-          
-      - if: github.actor == "release-please[bot]"
-        name: setup-git-config
-        run: |
           git config user.name "release-please[bot]"
           git config user.email "55107282+release-please[bot]@users.noreply.github.com"
-          
-      - if: github.actor == "release-please[bot]"
-        name: push-commit
-        run: |
           git add cmd/cloud_sql_proxy/cloud_sql_proxy.go
           git commit -m "Update version"
           git push origin ${{ github.head_ref }}

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -18,7 +18,7 @@ jobs:
         name: find-and-replace-version
         run: |
           VERSION=$(cat version.txt)
-          sed -i -r 's/[0-9]+.[0-9]+.[0-9]+(-dev)?/'"$VERSION"'/' cmd/cloud_sql_proxy/cloud_sql_proxy.go
+          sed -i -r 's/(var versionString = ")[0-9]+.[0-9]+.[0-9]+(-dev)?/\1'"$VERSION"'/' cmd/cloud_sql_proxy/cloud_sql_proxy.go
           
       - if: github.actor == "release-please[bot]"
         name: setup-git-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,11 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM golang:1 as build
 
-ARG VERSION="1.18.1-dev"
-
 WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X main.versionString=$VERSION -X main.metadataString=container" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X main.metadataString=container" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final Stage
 FROM gcr.io/distroless/base-debian10:nonroot

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -15,13 +15,11 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM golang:1 as build
 
-ARG VERSION="1.18.1-dev"
-
 WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X main.versionString=$VERSION -X main.metadataString=container.alpine" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X main.metadataString=container.alpine" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM alpine:3

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -15,13 +15,11 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM golang:1 as build
 
-ARG VERSION="1.18.1-dev"
-
 WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X main.versionString=$VERSION -X main.metadataString=container.buster" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags "-X main.metadataString=container.buster" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM debian:buster


### PR DESCRIPTION
This GitHub Actions workflow checks out the source branch of any PR generated by `release-please[bot]` and pushes another commit to update the version string in the proxy. It *should* push the commit as release-please bot and get past CLA issues that way