### PR TITLE
chore: fix branch name on update-version workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -2,7 +2,7 @@
 name: update-version
 on:
   pull_request:
-          branches: [master]
+          branches: ['master']
           paths: 
             - 'version.txt'
 


### PR DESCRIPTION
## Change Description

The action isn't triggering and I suspect it's because of these missing quotes.


