### PR TITLE
feat: use regionalized instance ids to prevent global conflicts with sqladmin v1

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -345,7 +345,7 @@ func listInstances(ctx context.Context, cl *http.Client, projects []string) ([]s
 				for _, in := range r.Items {
 					// The Proxy is only support on Second Gen
 					if in.BackendType == "SECOND_GEN" {
-						ch <- fmt.Sprintf("%s:%s:%s", in.Project, in.Region, in.Name)
+						ch <- in.ConnectionName
 					}
 				}
 				return nil

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -231,8 +231,9 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 	}
 	// Parse the instance connection name - everything before the "=".
 	ret.Instance = args[0]
-	proj, _, name := util.SplitName(ret.Instance)
-	if proj == "" || name == "" {
+	proj, region, name := util.SplitName(ret.Instance)
+	regionName := fmt.Sprintf("%s~%s", region, name)
+	if proj == "" || region == "" || name == "" {
 		return instanceConfig{}, fmt.Errorf("invalid instance connection string: must be in the form `project:region:instance-name`; invalid name was %q", args[0])
 	}
 	if len(args) == 1 {
@@ -269,7 +270,7 @@ func parseInstanceConfig(dir, instance string, cl *http.Client) (instanceConfig,
 	if *host != "" {
 		sql.BasePath = *host
 	}
-	inst, err := sql.Instances.Get(proj, name).Do()
+	inst, err := sql.Instances.Get(proj, regionName).Do()
 	if err != nil {
 		return instanceConfig{}, err
 	}

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -169,8 +169,9 @@ func (s *RemoteCertSource) Local(instance string) (ret tls.Certificate, err erro
 		return ret, err
 	}
 
-	p, _, n := util.SplitName(instance)
-	req := s.serv.SslCerts.CreateEphemeral(p, n,
+	p, region, n := util.SplitName(instance)
+	regionName := fmt.Sprintf("%s~%s", region, n)
+	req := s.serv.SslCerts.CreateEphemeral(p, regionName,
 		&sqladmin.SslCertsCreateEphemeralRequest{
 			PublicKey: string(pem.EncodeToMemory(&pem.Block{Bytes: pkix, Type: "RSA PUBLIC KEY"})),
 		},
@@ -228,7 +229,8 @@ func (s *RemoteCertSource) findIPAddr(data *sqladmin.DatabaseInstance, instance 
 // Remote returns the specified instance's CA certificate, address, and name.
 func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr, name, version string, err error) {
 	p, region, n := util.SplitName(instance)
-	req := s.serv.Instances.Get(p, n)
+	regionName := fmt.Sprintf("%s~%s", region, n)
+	req := s.serv.Instances.Get(p, regionName)
 
 	var data *sqladmin.DatabaseInstance
 	err = backoffAPIRetry("get instance", instance, func() error {

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -169,8 +169,8 @@ func (s *RemoteCertSource) Local(instance string) (ret tls.Certificate, err erro
 		return ret, err
 	}
 
-	p, region, n := util.SplitName(instance)
-	regionName := fmt.Sprintf("%s~%s", region, n)
+	p, r, n := util.SplitName(instance)
+	regionName := fmt.Sprintf("%s~%s", r, n)
 	req := s.serv.SslCerts.CreateEphemeral(p, regionName,
 		&sqladmin.SslCertsCreateEphemeralRequest{
 			PublicKey: string(pem.EncodeToMemory(&pem.Block{Bytes: pkix, Type: "RSA PUBLIC KEY"})),


### PR DESCRIPTION
Update the SQLAdmin API calls to use an instance name with a region prefix with the format <region>~<instance-name> to prevent issues with conflicting instance names when sqladmin v1 is released and instance names become regionally unique instead of globally unique
