### PR TITLE
Change refreshCfg caching behavior to hang onto valid configurations as long as possible 

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -32,7 +32,7 @@ import (
 const (
 	DefaultRefreshCfgThrottle = time.Minute
 	keepAlivePeriod           = time.Minute
-	defaultRefreshCertBuffer  = 30 * time.Second
+	defaultRefreshCertBuffer  = 2 * time.Minute
 )
 
 var (

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -246,12 +246,6 @@ func TestShutdownTerminatesEarly(t *testing.T) {
 }
 
 func TestRefreshTimer(t *testing.T) {
-	oldRefreshCertBuffer := refreshCertBuffer
-	defer func() {
-		refreshCertBuffer = oldRefreshCertBuffer
-	}()
-	refreshCertBuffer = time.Second
-
 	timeToExpire := 5 * time.Second
 	b := &fakeCerts{}
 	certCreated := time.Now()
@@ -266,6 +260,7 @@ func TestRefreshTimer(t *testing.T) {
 			return nil, errFakeDial
 		},
 		RefreshCfgThrottle: 20 * time.Millisecond,
+		RefreshCertBuffer:  time.Second,
 	}
 	// Call Dial to cache the cert.
 	if _, err := c.Dial(instance); err != errFakeDial {


### PR DESCRIPTION
## Change Description

The caching logic in `refreshCfg` makes it possible to replace a perfectly valid cert with an error. This can cause production issues that are unnecessary, in my opinion. 

If an error gets cached, it's not possible to attempt to retry the refresh for a full minute. If we had never cached the error in the first place, we could wait a minute to retry the refresh without having to return any errors because we still have a valid cert from the last successful call to refreshCfg.


## Checklist

- [ ] https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/519

## Relevant issues:

- Fixes https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/519