### PR TITLE
fix(containers): Allow non-root users to mount fuse filesystems for alpine and buster images

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -25,11 +25,12 @@ RUN go build -ldflags "-X main.metadataString=container.alpine" -o cloud_sql_pro
 FROM alpine:3
 RUN apk add --no-cache \ 
     ca-certificates \
-    fuse \
     libc6-compat
+# Install fuse and allow enable non-root users to mount
+RUN apk add --no-cache fuse && sed -i 's/^#user_allow_other$/user_allow_other/g' /etc/fuse.conf
 # Add a non-root user matching the nonroot user from the main container
 RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
-# set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
+# Set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 
 COPY --from=build --chown=nonroot /go/src/cloudsql-proxy/cloud_sql_proxy /cloud_sql_proxy

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -23,12 +23,12 @@ RUN go build -ldflags "-X main.metadataString=container.buster" -o cloud_sql_pro
 
 # Final stage
 FROM debian:buster
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    fuse
+RUN apt-get update && apt-get install -y ca-certificates
+# Install fuse and allow enable non-root users to mount
+RUN apt-get update && apt-get install -y fuse && sed -i 's/^#user_allow_other$/user_allow_other/g' /etc/fuse.conf
 # Add a non-root user matching the nonroot user from the main container
 RUN groupadd -g 65532 -r nonroot && useradd -u 65532 -g 65532 -r nonroot
-# set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
+# Set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 
 COPY --from=build --chown=nonroot /go/src/cloudsql-proxy/cloud_sql_proxy /cloud_sql_proxy


### PR DESCRIPTION
## Change Description

Enabled the "user_allow_other" option in `/etc/fuse.conf`. This allows non-root users to mount fuse filesystems, which allows fuse mode to work when deployed to k8s. 

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #444 