### PR TITLE
feat: add `-close-idle` flag to close idle connections during shutdown window

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ cloud_sql_proxy takes a few arguments to configure what instances to connect to 
 * `-skip_failed_instance_config`: Setting this flag will allow you to prevent the proxy from terminating when
 	some instance configurations could not be parsed and/or are unavailable.
 * `-log_debug_stdout=true`: This is to log non-error output to stdOut instead of stdErr. For example, if you don't want connection related messages to log as errors, set this flag to true. Defaults to false.
+* `-close_idle=true`: Enable closing "idle" connections during the shutdown grace period.
+* `-close_idle_timeout=5s`: How long to wait before considering a connection "idle" (during shutdown).
 
 Note: `-instances` and `-instances_metadata` may be used at the same time but
 are not compatible with the `-fuse` flag.

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -92,6 +92,11 @@ You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same
 
 	// Setting to choose what API to connect to
 	host = flag.String("host", "", "When set, the proxy uses this host as the base API path. Example: https://sqladmin.googleapis.com")
+
+	// Close "idle" connections during the shutdown grace period.
+	closeIdle = flag.Bool("close_idle", false, "During shutdown close idle connections")
+	// How long to wait before considering a connection "idle".
+	closeIdleTimeout = flag.Duration("close_idle_timeout", 5*time.Second, "The amount of time to wait before considering a connection idle.")
 )
 
 const (
@@ -546,7 +551,7 @@ func main() {
 		<-signals
 		logging.Infof("Received TERM signal. Waiting up to %s before terminating.", *termTimeout)
 
-		err := proxyClient.Shutdown(*termTimeout)
+		err := proxyClient.Shutdown(*termTimeout, *closeIdle, *closeIdleTimeout)
 		if err == nil {
 			os.Exit(0)
 		}

--- a/cmd/cloud_sql_proxy/proxy.go
+++ b/cmd/cloud_sql_proxy/proxy.go
@@ -166,7 +166,7 @@ func listenInstance(dst chan<- proxy.Conn, cfg instanceConfig) (net.Listener, er
 				clientConn.SetKeepAlivePeriod(1 * time.Minute)
 
 			}
-			dst <- proxy.Conn{cfg.Instance, c}
+			dst <- proxy.Conn{cfg.Instance, &proxy.TrackedConn{Conn: c}}
 		}
 	}()
 

--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -174,7 +174,7 @@ func (r *fsRoot) newConn(instance string, c net.Conn) {
 	r.RLock()
 	// dst will be nil if Close has been called already.
 	if ch := r.dst; ch != nil {
-		ch <- proxy.Conn{instance, c}
+		ch <- proxy.Conn{instance, &proxy.TrackedConn{Conn: c}}
 	} else {
 		logging.Errorf("Ignored new conn request to %q: system has been closed", instance)
 	}

--- a/proxy/proxy/conn.go
+++ b/proxy/proxy/conn.go
@@ -1,0 +1,64 @@
+package proxy
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/logging"
+)
+
+type IdleTrackingConn interface {
+	net.Conn
+	idleDuration() time.Duration
+}
+
+type TrackedConn struct {
+	net.Conn
+	sync.Mutex
+	lastActivity time.Time
+}
+
+func (t *TrackedConn) Write(b []byte) (int, error) {
+	x, y := t.Conn.Write(b)
+	t.Lock()
+	t.lastActivity = time.Now()
+	t.Unlock()
+	return x, y
+}
+
+func (t *TrackedConn) Read(b []byte) (int, error) {
+	x, y := t.Conn.Read(b)
+	t.Lock()
+	t.lastActivity = time.Now()
+	t.Unlock()
+	return x, y
+}
+
+func (t *TrackedConn) idleDuration() time.Duration {
+	t.Lock()
+	defer t.Unlock()
+	return time.Since(t.lastActivity)
+}
+
+type dbgConn struct {
+	IdleTrackingConn
+}
+
+func (d dbgConn) Write(b []byte) (int, error) {
+	x, y := d.IdleTrackingConn.Write(b)
+	logging.Verbosef("write(%q) => (%v, %v)", b, x, y)
+	return x, y
+}
+
+func (d dbgConn) Read(b []byte) (int, error) {
+	x, y := d.IdleTrackingConn.Read(b)
+	logging.Verbosef("read: (%v, %v) => %q", x, y, b[:x])
+	return x, y
+}
+
+func (d dbgConn) Close() error {
+	err := d.IdleTrackingConn.Close()
+	logging.Verbosef("close: %v", err)
+	return err
+}


### PR DESCRIPTION
## Change Description

During the shutdown grace period, cloudsql-proxy should close idle connections, so that application code is able to cycle these connections out of it's connection pool prior to the proxy becoming unreachable.

This changeset implements this feature via keeping track of the last read/write activity on each connection, and during shutdown looping through and finding those with last activity times older than a configurable idle timeout threshold.

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #536 