### PR TITLE
fix: Ensure neccesary fields are 64-bit aligned

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -60,6 +60,13 @@ type CertSource interface {
 // Client is a type to handle connecting to a Server. All fields are required
 // unless otherwise specified.
 type Client struct {
+	// ConnectionsCounter is used to enforce the optional maxConnections limit
+	ConnectionsCounter uint64
+
+	// MaxConnections is the maximum number of connections to establish
+	// before refusing new connections. 0 means no limit.
+	MaxConnections uint64
+
 	// Port designates which remote port should be used when connecting to
 	// instances. This value is defined by the server-side code, but for now it
 	// should always be 3307.
@@ -95,13 +102,6 @@ type Client struct {
 	// RefreshCertBuffer is the amount of time before the configuration expires to
 	// attempt to refresh it. If not set, it defaults to 5 minutes.
 	RefreshCfgBuffer time.Duration
-
-	// MaxConnections is the maximum number of connections to establish
-	// before refusing new connections. 0 means no limit.
-	MaxConnections uint64
-
-	// ConnectionsCounter is used to enforce the optional maxConnections limit
-	ConnectionsCounter uint64
 }
 
 type cacheEntry struct {

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 const instance = "instance-name"
@@ -283,5 +284,13 @@ func TestRefreshTimer(t *testing.T) {
 	}
 	if !newCfg.lastRefreshed.After(cfg.lastRefreshed) {
 		t.Error("expected cert to be refreshed.")
+	}
+}
+
+func TestSyncAtomicAlignment(t *testing.T) {
+	// The sync/atomic pkg has a bug that requires the developer to guarantee 64-bit alignment when using 64-bit functions on 32-bit systems. 
+	c := &Client{}
+	if a := unsafe.Offsetof(c.ConnectionsCounter); a%64 != 0 {
+		t.Errorf("Client.ConnectionsCounter is not aligned: want %v, got %v", 0, a)
 	}
 }

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -288,7 +288,7 @@ func TestRefreshTimer(t *testing.T) {
 }
 
 func TestSyncAtomicAlignment(t *testing.T) {
-	// The sync/atomic pkg has a bug that requires the developer to guarantee 64-bit alignment when using 64-bit functions on 32-bit systems. 
+	// The sync/atomic pkg has a bug that requires the developer to guarantee 64-bit alignment when using 64-bit functions on 32-bit systems.
 	c := &Client{}
 	if a := unsafe.Offsetof(c.ConnectionsCounter); a%64 != 0 {
 		t.Errorf("Client.ConnectionsCounter is not aligned: want %v, got %v", 0, a)


### PR DESCRIPTION
## Change Description

Moves the `Client.ConnectionsCounter`  field to the start of the struct since these values are guaranteed to be 64-bit aligned. Also adds a regression test to ensure that it doesn't get moved out of alignment in the future. 


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #543 