### PR TITLE
feat: Added '-enable_iam_login' flag for IAM db authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cloud_sql_proxy takes a few arguments to configure what instances to connect to 
 * `-skip_failed_instance_config`: Setting this flag will allow you to prevent the proxy from terminating when
 	some instance configurations could not be parsed and/or are unavailable.
 * `-log_debug_stdout=true`: This is to log non-error output to stdOut instead of stdErr. For example, if you don't want connection related messages to log as errors, set this flag to true. Defaults to false.
-* `-enable_iam_login`: This is to configure the proxy using Cloud SQL IAM authentication. It will consolidate gcloud credential into ephemeral cert that will be checked on server side.
+* `-enable_iam_login`: This enables the proxy to use Cloud SQL IAM database authentication. This will cause the proxy to use IAM account credentials for database user authentication. 
 
 Note: `-instances` and `-instances_metadata` may be used at the same time but
 are not compatible with the `-fuse` flag.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ cloud_sql_proxy takes a few arguments to configure what instances to connect to 
 * `-skip_failed_instance_config`: Setting this flag will allow you to prevent the proxy from terminating when
 	some instance configurations could not be parsed and/or are unavailable.
 * `-log_debug_stdout=true`: This is to log non-error output to stdOut instead of stdErr. For example, if you don't want connection related messages to log as errors, set this flag to true. Defaults to false.
+* `-enable_iam_login`: This is to configure the proxy using Cloud SQL IAM authentication. It will consolidate gcloud credential into ephemeral cert that will be checked on server side.
 
 Note: `-instances` and `-instances_metadata` may be used at the same time but
 are not compatible with the `-fuse` flag.

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -86,6 +86,8 @@ can be removed automatically by this program.`)
 	tokenFile = flag.String("credential_file", "", `If provided, this json file will be used to retrieve Service Account credentials.
 You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same effect.`)
 	ipAddressTypes = flag.String("ip_address_types", "PUBLIC,PRIVATE", "Default to be 'PUBLIC,PRIVATE'. Options: a list of strings separated by ',', e.g. 'PUBLIC,PRIVATE' ")
+	// Settings for IAM db proxy authentication
+	enableIAMLogin = flag.Bool("enable_iam_login", false, "Enables IAM DB proxy authentication")
 
 	skipInvalidInstanceConfigs = flag.Bool("skip_failed_instance_config", false, `Setting this flag will allow you to prevent the proxy from terminating when
 	some instance configurations could not be parsed and/or are unavailable.`)
@@ -122,6 +124,10 @@ Authorization:
     parameter or set the GOOGLE_APPLICATION_CREDENTIALS environment variable.
     This will override gcloud or GCE (Google Compute Engine) credentials,
     if they exist.
+
+  * To configure the proxy using IAM authentication, pass the -enable_iam_login
+	  flag. This will consolidate gcloud credential into ephemeral cert that will
+		be checked on server side.
 
 General:
   -quiet
@@ -271,33 +277,35 @@ func checkFlags(onGCE bool) error {
 	return nil
 }
 
-func authenticatedClientFromPath(ctx context.Context, f string) (*http.Client, error) {
+func authenticatedClientFromPath(ctx context.Context, f string) (*http.Client, oauth2.TokenSource, error) {
 	all, err := ioutil.ReadFile(f)
 	if err != nil {
-		return nil, fmt.Errorf("invalid json file %q: %v", f, err)
+		return nil, nil, fmt.Errorf("invalid json file %q: %v", f, err)
 	}
 	// First try and load this as a service account config, which allows us to see the service account email:
 	if cfg, err := goauth.JWTConfigFromJSON(all, proxy.SQLScope); err == nil {
 		logging.Infof("using credential file for authentication; email=%s", cfg.Email)
-		return cfg.Client(ctx), nil
+		return cfg.Client(ctx), cfg.TokenSource(ctx), nil
 	}
 
 	cred, err := goauth.CredentialsFromJSON(ctx, all, proxy.SQLScope)
 	if err != nil {
-		return nil, fmt.Errorf("invalid json file %q: %v", f, err)
+		return nil, nil, fmt.Errorf("invalid json file %q: %v", f, err)
 	}
 	logging.Infof("using credential file for authentication; path=%q", f)
-	return oauth2.NewClient(ctx, cred.TokenSource), nil
+	return oauth2.NewClient(ctx, cred.TokenSource), cred.TokenSource, nil
 }
 
-func authenticatedClient(ctx context.Context) (*http.Client, error) {
-	if *tokenFile != "" {
-		return authenticatedClientFromPath(ctx, *tokenFile)
-	} else if tok := *token; tok != "" {
-		src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tok})
-		return oauth2.NewClient(ctx, src), nil
-	} else if f := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); f != "" {
-		return authenticatedClientFromPath(ctx, f)
+func authenticatedClient(ctx context.Context) (*http.Client, oauth2.TokenSource, error) {
+	if !*enableIAMLogin {
+		if *tokenFile != "" {
+			return authenticatedClientFromPath(ctx, *tokenFile)
+		} else if tok := *token; tok != "" {
+			src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tok})
+			return oauth2.NewClient(ctx, src), src, nil
+		} else if f := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); f != "" {
+			return authenticatedClientFromPath(ctx, f)
+		}
 	}
 
 	// If flags or env don't specify an auth source, try either gcloud or application default
@@ -307,10 +315,10 @@ func authenticatedClient(ctx context.Context) (*http.Client, error) {
 		src, err = goauth.DefaultTokenSource(ctx, proxy.SQLScope)
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return oauth2.NewClient(ctx, src), nil
+	return oauth2.NewClient(ctx, src), src, nil
 }
 
 func stringList(s string) []string {
@@ -462,7 +470,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	client, err := authenticatedClient(ctx)
+	client, tokSrc, err := authenticatedClient(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -497,6 +505,8 @@ func main() {
 			IgnoreRegion:   !*checkRegion,
 			UserAgent:      userAgentFromVersionString(),
 			IPAddrTypeOpts: ipAddrTypeOptsInput,
+			EnableIAMLogin: *enableIAMLogin,
+			TokenSource:    tokSrc,
 		}),
 		Conns:              connset,
 		RefreshCfgThrottle: refreshCfgThrottle,

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -126,8 +126,8 @@ Authorization:
     if they exist.
 
   * To configure the proxy using IAM authentication, pass the -enable_iam_login
-	  flag. This will consolidate gcloud credential into ephemeral cert that will
-		be checked on server side.
+	  flag. This will cause the proxy to use IAM account credentials for 
+	  database user authentication. 
 
 General:
   -quiet

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -87,7 +87,7 @@ can be removed automatically by this program.`)
 You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same effect.`)
 	ipAddressTypes = flag.String("ip_address_types", "PUBLIC,PRIVATE", "Default to be 'PUBLIC,PRIVATE'. Options: a list of strings separated by ',', e.g. 'PUBLIC,PRIVATE' ")
 	// Settings for IAM db proxy authentication
-	enableIAMLogin = flag.Bool("enable_iam_login", false, "Enables user authentication using Cloud SQL's IAM DB Authentication.")
+	enableIAMLogin = flag.Bool("enable_iam_login", false, "Enables database user authentication using Cloud SQL's IAM DB Authentication.")
 
 	skipInvalidInstanceConfigs = flag.Bool("skip_failed_instance_config", false, `Setting this flag will allow you to prevent the proxy from terminating when
 	some instance configurations could not be parsed and/or are unavailable.`)

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -87,7 +87,7 @@ can be removed automatically by this program.`)
 You may set the GOOGLE_APPLICATION_CREDENTIALS environment variable for the same effect.`)
 	ipAddressTypes = flag.String("ip_address_types", "PUBLIC,PRIVATE", "Default to be 'PUBLIC,PRIVATE'. Options: a list of strings separated by ',', e.g. 'PUBLIC,PRIVATE' ")
 	// Settings for IAM db proxy authentication
-	enableIAMLogin = flag.Bool("enable_iam_login", false, "Enables IAM DB proxy authentication")
+	enableIAMLogin = flag.Bool("enable_iam_login", false, "Enables user authentication using Cloud SQL's IAM DB Authentication.")
 
 	skipInvalidInstanceConfigs = flag.Bool("skip_failed_instance_config", false, `Setting this flag will allow you to prevent the proxy from terminating when
 	some instance configurations could not be parsed and/or are unavailable.`)
@@ -297,15 +297,13 @@ func authenticatedClientFromPath(ctx context.Context, f string) (*http.Client, o
 }
 
 func authenticatedClient(ctx context.Context) (*http.Client, oauth2.TokenSource, error) {
-	if !*enableIAMLogin {
-		if *tokenFile != "" {
-			return authenticatedClientFromPath(ctx, *tokenFile)
-		} else if tok := *token; tok != "" {
-			src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tok})
-			return oauth2.NewClient(ctx, src), src, nil
-		} else if f := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); f != "" {
-			return authenticatedClientFromPath(ctx, f)
-		}
+	if *tokenFile != "" {
+		return authenticatedClientFromPath(ctx, *tokenFile)
+	} else if tok := *token; tok != "" {
+		src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tok})
+		return oauth2.NewClient(ctx, src), src, nil
+	} else if f := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); f != "" {
+		return authenticatedClientFromPath(ctx, f)
 	}
 
 	// If flags or env don't specify an auth source, try either gcloud or application default

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -191,10 +191,7 @@ func (s *RemoteCertSource) Local(instance string) (ret tls.Certificate, err erro
 		if e != nil {
 			return ret, e
 		}
-		createEphemeralRequest = sqladmin.SslCertsCreateEphemeralRequest{
-			PublicKey:   pubKey,
-			AccessToken: tok.AccessToken,
-		}
+		createEphemeralRequest.AccessToken = tok.AccessToken
 	}
 	req := s.serv.SslCerts.CreateEphemeral(p, regionName, &createEphemeralRequest)
 


### PR DESCRIPTION
## Change Description

This PR introduces the client side changes needed for utilizing the access token for cloudsql proxy IAM database authentication. The feature is gated by newly introduced flag `--enable_iam_login`. When enabled it includes the access token in the `sqladmin.SslCertsCreateEphemeralRequest` and send the request to create a ephemeral cert with access token info in it, which will later be used to perform IAM authentication. The access token has TTL of 1 hour and the ssl cert will be refreshed whenever access token expires or cert expires. 

