### PR TITLE
chore: renovate bot uses chore for all commits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitTypeAll(chore)"
   ],
   "prConcurrentLimit": 0,
   "rebaseStalePrs": true,


### PR DESCRIPTION
See https://github.com/renovatebot/renovate/blob/master/docs/usage/semantic-commits.md#changing-the-semantic-commit-type.