### PR TITLE
feat: add ARM releases

### DIFF
--- a/.build/gcs_upload.yaml
+++ b/.build/gcs_upload.yaml
@@ -36,6 +36,24 @@ steps:
     args:
       - "-c"
       - 'go build -ldflags "-X main.versionString=${_VERSION} -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
+  - id: linux.arm64
+    name: "golang:1.16"
+    env:
+      - "GOOS=linux"
+      - "GOARCH=arm64"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - 'go build -ldflags "-X main.versionString=${_VERSION} -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
+  - id: linux.arm
+    name: "golang:1.16"
+    env:
+      - "GOOS=linux"
+      - "GOARCH=arm"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - 'go build -ldflags "-X main.versionString=${_VERSION} -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
   - id: darwin.amd64
     name: "golang:1.14"
     env:
@@ -54,6 +72,15 @@ steps:
     args:
       - "-c"
       - 'go build -ldflags "-X main.versionString=${_VERSION}  -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
+  - id: darwin.arm
+    name: "golang:1.16"
+    env:
+      - "GOOS=linux"
+      - "GOARCH=arm"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - 'go build -ldflags "-X main.versionString=${_VERSION} -X main.metadataString=$$GOOS.$$GOARCH" -o cloud_sql_proxy.$$GOOS.$$GOARCH ./cmd/cloud_sql_proxy'
   - id: windows.amd64
     name: "golang:1.14"
     env:


### PR DESCRIPTION
## Change Description

Added steps to compile binaries for Linux/ARM32 and Linux/ARM64, as well as Darwin/ARM64. The Linux versions have been tested with QEMU, but not on an actual ARM machine yet. 
Not sure how to test the Darwin one (for M1 Macs), although it's probably low priority, since Apple says that [the new Macs have Rosetta to run programs compiled for AMD64](https://support.apple.com/en-us/HT211861). 

## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)