### PR TITLE
fix: verify TokenSource exists in TokenExpiration()

### DIFF
--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -297,14 +297,14 @@ func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr
 }
 
 // TokenExpiration returns the expiration time for token source associated with remote cert source.
-func (s *RemoteCertSource) TokenExpiration() (ret time.Time, err error) {
+func (s *RemoteCertSource) TokenExpiration() (time.Time, error) {
 	// if no token is being used, return zero for expiration
 	if s.TokenSource == nil {
-		return ret, err
+		return time.Time{}, nil
 	}
 	tok, err := s.TokenSource.Token()
 	if err != nil {
-		return ret, err
+		return time.Time{}, err
 	}
 	return tok.Expiry, nil
 }

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -298,6 +298,10 @@ func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr
 
 // TokenExpiration returns the expiration time for token source associated with remote cert source.
 func (s *RemoteCertSource) TokenExpiration() (ret time.Time, err error) {
+	// if no token is being used, return zero for expiration
+	if s.TokenSource == nil {
+		return ret, err
+	}
 	tok, err := s.TokenSource.Token()
 	if err != nil {
 		return ret, err

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -239,7 +239,7 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, vers
 		return "", nil, "", err
 	}
 	expire := mycert.Leaf.NotAfter
-	if expire.After(tokenExpiry) {
+	if !tokenExpiry.IsZero() && expire.After(tokenExpiry) {
 		expire = tokenExpiry
 	}
 	now := time.Now()

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -113,7 +113,7 @@ func TestPostgresIAMDBAuthn(t *testing.T) {
 }
 
 func TestPostgresHook(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s sslmode=disable", *postgresConnName, *postgresUser, *postgresPass, *postgresDb)


### PR DESCRIPTION
## Change Description

Updates `TokenExpiration()` to return a zero value if TokenSource is unset.

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #640 