### PR TITLE
chore: ensure IAM user is present before test run

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -9,6 +9,7 @@ export POSTGRES_CONNECTION_NAME="project:region:instance"
 export POSTGRES_USER="postgres-user"
 export POSTGRES_PASS="postgres-password"
 export POSTGRES_DB="postgres-db-name"
+export POSTGRES_USER_IAM="some-user-with-db-access@example.com"
 
 export SQLSERVER_CONNECTION_NAME="project:region:instance"
 export SQLSERVER_USER="sqlserver-user"

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -54,8 +54,11 @@ func requirePostgresVars(t *testing.T) {
 		t.Fatal("'postgres_pass' not set")
 	case *postgresDb:
 		t.Fatal("'postgres_db' not set")
+	case *postgresIAMUser:
+		t.Fatal("'postgres_user_iam' not set")
 	}
 }
+
 func TestPostgresTcp(t *testing.T) {
 	requirePostgresVars(t)
 

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -54,8 +54,6 @@ func requirePostgresVars(t *testing.T) {
 		t.Fatal("'postgres_pass' not set")
 	case *postgresDb:
 		t.Fatal("'postgres_db' not set")
-	case *postgresIAMUser:
-		t.Fatal("'postgres_user_iam' not set")
 	}
 }
 
@@ -88,6 +86,9 @@ func TestPostgresConnLimit(t *testing.T) {
 
 func TestPostgresIAMDBAuthn(t *testing.T) {
 	requirePostgresVars(t)
+	if *postgresIAMUser == "" {
+		t.Fatal("'postgres_user_iam' not set")
+	}
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Also, add the associated environment variable to .envrc.example.