### PR TITLE
fix: use new oauth2 token with cert refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Compiled binary
 cmd/cloud_sql_proxy/cloud_sql_proxy
+cloud_sql_proxy

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -184,7 +184,7 @@ func refreshToken(ts oauth2.TokenSource, tok1 *oauth2.Token) (*oauth2.Token, err
 
 // Local returns a certificate that may be used to establish a TLS
 // connection to the specified instance.
-func (s *RemoteCertSource) Local(instance string) (ret tls.Certificate, err error) {
+func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 	pkix, err := x509.MarshalPKIXPublicKey(&s.key.PublicKey)
 	if err != nil {
 		return tls.Certificate{}, err
@@ -204,12 +204,10 @@ func (s *RemoteCertSource) Local(instance string) (ret tls.Certificate, err erro
 		if err != nil {
 			return tls.Certificate{}, err
 		}
-		logging.Infof("Existing token expiration: %v", tok.Expiry)
 		tok, err = refreshToken(s.TokenSource, tok)
 		if err != nil {
 			return tls.Certificate{}, err
 		}
-		logging.Infof("New token expiration: %s", tok.Expiry)
 		createEphemeralRequest.AccessToken = tok.AccessToken
 	}
 	req := s.serv.SslCerts.CreateEphemeral(p, regionName, &createEphemeralRequest)

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -222,21 +222,17 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, vers
 	certs.AddCert(scert)
 
 	certExpiration := mycert.Leaf.NotAfter
-	logging.Infof("certExpiration = %v", certExpiration)
 	if c.Certs.IAMLoginEnabled() {
 		tokenExpiration, tokErr := c.Certs.TokenExpiration()
 		if tokErr != nil {
 			return "", nil, "", tokErr
 		}
-		logging.Infof("tokenExpiraton = %v", tokenExpiration)
 		if certExpiration.After(tokenExpiration) {
-			logging.Infof("cert expiration comes after token expiration; using token expiration")
 			certExpiration = tokenExpiration
 		}
 	}
 	now := time.Now()
 	timeToRefresh := certExpiration.Sub(now) - refreshCfgBuffer
-	logging.Infof("timeToRefresh = %v", timeToRefresh)
 	if timeToRefresh <= 0 {
 		err = fmt.Errorf("new ephemeral certificate expires too soon: current time: %v, certificate expires: %v", now, certExpiration)
 		logging.Errorf("ephemeral certificate (%+v) error: %v", mycert, err)

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -71,6 +71,10 @@ func (cs *blockingCertSource) TokenExpiration() (ret time.Time, err error) {
 	return cs.tokenExpire, nil
 }
 
+func (cs *blockingCertSource) IAMLoginEnabled() bool {
+	return true
+}
+
 func TestContextDialer(t *testing.T) {
 	b := &fakeCerts{}
 	c := &Client{
@@ -328,6 +332,7 @@ func TestRefreshTimerTokenExpires(t *testing.T) {
 	}
 
 	time.Sleep(timeToExpire - time.Since(certCreated))
+	time.Sleep(5 * time.Second)
 	// Check if cert was refreshed in the background, without calling Dial again.
 	c.cacheL.Lock()
 	newCfg, ok := c.cfgCache[instance]

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -332,7 +332,6 @@ func TestRefreshTimerTokenExpires(t *testing.T) {
 	}
 
 	time.Sleep(timeToExpire - time.Since(certCreated))
-	time.Sleep(5 * time.Second)
 	// Check if cert was refreshed in the background, without calling Dial again.
 	c.cacheL.Lock()
 	newCfg, ok := c.cfgCache[instance]

--- a/proxy/util/gcloudutil.go
+++ b/proxy/util/gcloudutil.go
@@ -80,7 +80,7 @@ func GcloudConfig() (*GcloudConfigData, error) {
 	}
 
 	buf, errbuf := new(bytes.Buffer), new(bytes.Buffer)
-	cmd := exec.Command(gcloudCmd, "--format", "json", "config", "config-helper")
+	cmd := exec.Command(gcloudCmd, "--format", "json", "config", "config-helper", "--min-expiry", "1h")
 	cmd.Stdout = buf
 	cmd.Stderr = errbuf
 
@@ -114,9 +114,5 @@ func (src *gcloudTokenSource) Token() (*oauth2.Token, error) {
 }
 
 func GcloudTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	cfg, err := GcloudConfig()
-	if err != nil {
-		return nil, err
-	}
-	return oauth2.ReuseTokenSource(cfg.oauthToken(), &gcloudTokenSource{}), nil
+	return &gcloudTokenSource{}, nil
 }


### PR DESCRIPTION
When clients use IAM authorization, an OAuth2 token is inserted into the
local certificate. In a previous commit, that token could expire within
the configured buffer (i.e., 5 minutes), causing the proxy to fail to
refresh its configuration and to report that the "new ephemeral
certificate expires too soon." Because the code always checked the token
expiration and the certificate expiration, this bug would affect both
clients using IAM auth and clients *not* using it.

This commit ensures the token's expiration is only considered when IAM
auth has been enabled, and when it has been enabled, this commit
likewise ensures the token's expiration is well beyond the buffer.

Fixes #643.
