### PR TITLE
fix: perform initial gcloud check and reuse token

### DIFF
--- a/proxy/util/gcloudutil.go
+++ b/proxy/util/gcloudutil.go
@@ -114,5 +114,10 @@ func (src *gcloudTokenSource) Token() (*oauth2.Token, error) {
 }
 
 func GcloudTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	return &gcloudTokenSource{}, nil
+	src := &gcloudTokenSource{}
+	tok, err := src.Token()
+	if err != nil {
+		return nil, err
+	}
+	return oauth2.ReuseTokenSource(tok, src), nil
 }


### PR DESCRIPTION
## Change Description

Reverts behavior to verify a gcloud token is available before using it as a TokenSource, and caches the token when possible.


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #655