### PR TITLE
fix: ensure certificate expiration is correct

### DIFF
--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -241,11 +241,6 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 	}, nil
 }
 
-// IAMLoginEnabled reports whether IAM login has been enabled.
-func (s *RemoteCertSource) IAMLoginEnabled() bool {
-	return s.EnableIAMLogin
-}
-
 func parseCert(pemCert string) (*x509.Certificate, error) {
 	bl, _ := pem.Decode([]byte(pemCert))
 	if bl == nil {
@@ -325,17 +320,4 @@ func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr
 	c, err := parseCert(data.ServerCaCert.Cert)
 
 	return c, ipAddrInUse, p + ":" + n, data.DatabaseVersion, err
-}
-
-// TokenExpiration returns the expiration time for token source associated with remote cert source.
-func (s *RemoteCertSource) TokenExpiration() (time.Time, error) {
-	// if no token is being used, return zero for expiration
-	if s.TokenSource == nil {
-		return time.Time{}, nil
-	}
-	tok, err := s.TokenSource.Token()
-	if err != nil {
-		return time.Time{}, err
-	}
-	return tok.Expiry, nil
 }

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -50,15 +50,11 @@ type Conn struct {
 
 // CertSource is how a Client obtains various certificates required for operation.
 type CertSource interface {
-	// IAMLoginEnabled reports whether IAM Login has been enabled.
-	IAMLoginEnabled() bool
 	// Local returns a certificate that can be used to authenticate with the
 	// provided instance.
 	Local(instance string) (tls.Certificate, error)
 	// Remote returns the instance's CA certificate, address, and name.
 	Remote(instance string) (cert *x509.Certificate, addr, name, version string, err error)
-	// TokenExpiration returns expiration time of the token information.
-	TokenExpiration() (time.Time, error)
 }
 
 // Client is a type to handle connecting to a Server. All fields are required

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -237,15 +237,6 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, vers
 	}
 
 	certExpiration := mycert.Leaf.NotAfter
-	if c.Certs.IAMLoginEnabled() {
-		tokenExpiration, tokErr := c.Certs.TokenExpiration()
-		if tokErr != nil {
-			return "", nil, "", tokErr
-		}
-		if certExpiration.After(tokenExpiration) {
-			certExpiration = tokenExpiration
-		}
-	}
 	now := time.Now()
 	timeToRefresh := certExpiration.Sub(now) - refreshCfgBuffer
 	if timeToRefresh <= 0 {

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -41,9 +41,8 @@ type fakeCerts struct {
 }
 
 type blockingCertSource struct {
-	values      map[string]*fakeCerts
-	validUntil  time.Time
-	tokenExpire time.Time
+	values     map[string]*fakeCerts
+	validUntil time.Time
 }
 
 func (cs *blockingCertSource) Local(instance string) (tls.Certificate, error) {
@@ -67,14 +66,6 @@ func (cs *blockingCertSource) Remote(instance string) (cert *x509.Certificate, a
 	return &x509.Certificate{}, "fake address", "fake name", "fake version", nil
 }
 
-func (cs *blockingCertSource) TokenExpiration() (ret time.Time, err error) {
-	return cs.tokenExpire, nil
-}
-
-func (cs *blockingCertSource) IAMLoginEnabled() bool {
-	return true
-}
-
 func TestContextDialer(t *testing.T) {
 	b := &fakeCerts{}
 	c := &Client{
@@ -82,7 +73,6 @@ func TestContextDialer(t *testing.T) {
 			map[string]*fakeCerts{
 				instance: b,
 			},
-			forever,
 			forever,
 		},
 		ContextDialer: func(context.Context, string, string) (net.Conn, error) {
@@ -105,7 +95,6 @@ func TestClientCache(t *testing.T) {
 			map[string]*fakeCerts{
 				instance: b,
 			},
-			forever,
 			forever,
 		},
 		Dialer: func(string, string) (net.Conn, error) {
@@ -133,7 +122,6 @@ func TestConcurrentRefresh(t *testing.T) {
 			map[string]*fakeCerts{
 				instance: b,
 			},
-			forever,
 			forever,
 		},
 		Dialer: func(string, string) (net.Conn, error) {
@@ -175,7 +163,6 @@ func TestMaximumConnectionsCount(t *testing.T) {
 	b := &fakeCerts{}
 	certSource := blockingCertSource{
 		map[string]*fakeCerts{},
-		forever,
 		forever,
 	}
 	firstDialExited := make(chan struct{})
@@ -238,7 +225,6 @@ func TestShutdownTerminatesEarly(t *testing.T) {
 				instance: b,
 			},
 			forever,
-			forever,
 		},
 		Dialer: func(string, string) (net.Conn, error) {
 			return nil, nil
@@ -269,7 +255,6 @@ func TestRefreshTimer(t *testing.T) {
 			map[string]*fakeCerts{
 				instance: b,
 			},
-			certCreated.Add(timeToExpire),
 			certCreated.Add(timeToExpire),
 		},
 		Dialer: func(string, string) (net.Conn, error) {

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -270,48 +270,6 @@ func TestRefreshTimer(t *testing.T) {
 				instance: b,
 			},
 			certCreated.Add(timeToExpire),
-			forever,
-		},
-		Dialer: func(string, string) (net.Conn, error) {
-			return nil, errFakeDial
-		},
-		RefreshCfgThrottle: 20 * time.Millisecond,
-		RefreshCfgBuffer:   time.Second,
-	}
-	// Call Dial to cache the cert.
-	if _, err := c.Dial(instance); err != errFakeDial {
-		t.Fatalf("Dial(%s) failed: %v", instance, err)
-	}
-	c.cacheL.Lock()
-	cfg, ok := c.cfgCache[instance]
-	c.cacheL.Unlock()
-	if !ok {
-		t.Fatalf("expected instance to be cached")
-	}
-
-	time.Sleep(timeToExpire - time.Since(certCreated))
-	// Check if cert was refreshed in the background, without calling Dial again.
-	c.cacheL.Lock()
-	newCfg, ok := c.cfgCache[instance]
-	c.cacheL.Unlock()
-	if !ok {
-		t.Fatalf("expected instance to be cached")
-	}
-	if !newCfg.lastRefreshed.After(cfg.lastRefreshed) {
-		t.Error("expected cert to be refreshed.")
-	}
-}
-
-func TestRefreshTimerTokenExpires(t *testing.T) {
-	timeToExpire := 5 * time.Second
-	b := &fakeCerts{}
-	certCreated := time.Now()
-	c := &Client{
-		Certs: &blockingCertSource{
-			map[string]*fakeCerts{
-				instance: b,
-			},
-			forever,
 			certCreated.Add(timeToExpire),
 		},
 		Dialer: func(string, string) (net.Conn, error) {


### PR DESCRIPTION
This commit is a follow-on to #648 which only partially addressed the
issue reported in #643. In a previous commit, we ensured the associated
OAuth2 token was refreshed before requesting an ephemeral certificate.
However, the oauth2.TokenSource stored in certs.RemoteCertSource would
nonetheless report an unrefreshed token's expiration. As a result,
attempts to refresh the configuration would fail given the unrefreshed
token would expire too soon.

This commit takes a new approach by updating the leaf certificate's
expiration to be the earlier of the ephemeral certificate's expiration
or the token's expiration. It likewise removes any checks of the token's
expiration outside of certs.RemoteCertSource.

Fixes #643.