### PR TITLE
chore: ensure build process has enough time and all the code

### DIFF
--- a/.build/gcs_upload.yaml
+++ b/.build/gcs_upload.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+timeout: 900s
 options:
   env:
     - "GOPATH=/workspace/GOPATH"

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 .vscode/
 
 # Compiled binary
-cmd/cloud_sql_proxy/cloud_sql_proxy
-cloud_sql_proxy
+/cmd/cloud_sql_proxy/cloud_sql_proxy
+/cloud_sql_proxy


### PR DESCRIPTION
- Increase build timeout to 15 minutes now that we have more images to build
- Ensure gitignore strictly defines what to ignore so that Cloud Build doesn't fail to copy parts of our code tree.