### PR TITLE
fix: prevent refreshCfg from scheduling multiple refreshes

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -188,7 +188,8 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, vers
 	}
 	// Continuing past this point means a new refresh will be attempted,
 	// so lets mark the cache updated to prevent multiple routines from calling it at once
-	c.cfgCache[instance].lastRefreshed = time.Now()
+	old.lastRefreshed = time.Now()
+	c.cfgCache[instance] = old
 	c.cacheL.Unlock()
 
 	defer func() {

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -180,12 +180,16 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, vers
 		c.cfgCache = make(map[string]cacheEntry)
 	}
 	old, oldok := c.cfgCache[instance]
-	c.cacheL.Unlock()
 	if oldok && time.Since(old.lastRefreshed) < throttle {
+		c.cacheL.Unlock()
 		logging.Errorf("Throttling refreshCfg(%s): it was only called %v ago", instance, time.Since(old.lastRefreshed))
 		// Refresh was called too recently, just reuse the result.
 		return old.addr, old.cfg, old.version, old.err
 	}
+	// Continuing past this point means a new refresh will be attempted,
+	// so lets mark the cache updated to prevent multiple routines from calling it at once
+	c.cfgCache[instance].lastRefreshed = time.Now()
+	c.cacheL.Unlock()
 
 	defer func() {
 		// if we failed to refresh cfg do not throw out potentially valid one


### PR DESCRIPTION
## Change Description

Changes `refreshCfg` to update the `lastRefreshed` field of of the cached result once the decision to make a refresh has been made and before the cache lock is released. This fixes a race condition where more than one goroutine could attempt to perform a refresh. 


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #427