### PR TITLE
fix: shorten refresh window when cert duration is less than expected

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -236,7 +236,7 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, vers
 	now := time.Now()
 	timeToRefresh := certExpiration.Sub(now) - refreshCfgBuffer
 	if timeToRefresh <= 0 {
-		// If a new certificate expires before our buffer has expired, 
+		// If a new certificate expires before our buffer has expired,
 		// we should wait a bit and schedule a new refresh to much closer to the expiration's date
 		// TODO: This situation probably only occurs for Issue #622 - when the oauth2 token isn't refreshed before the cert is
 		timeToRefresh = certExpiration.Sub(now) - (5 * time.Second)


### PR DESCRIPTION
## Change Description

Shortens the time before doing a new refresh when the duration is less than expected, rather than returning an error. 

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Related to #662 (but probably doesn't fix)