### PR TITLE
fix: fix cache to prevent multiple concurrent refreshes

### DIFF
--- a/proxy/fuse/fuse.go
+++ b/proxy/fuse/fuse.go
@@ -239,7 +239,7 @@ func (r *fsRoot) Attr(ctx context.Context, a *fuse.Attr) error {
 // the README, it returns a node which is a symbolic link to a socket which
 // provides connectivity to a remote instance.  The instance which is connected
 // to is determined by req.Name.
-func (r *fsRoot) Lookup(_ context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (fs.Node, error) {
+func (r *fsRoot) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (fs.Node, error) {
 	if req.Name == "README" {
 		return readme{}, nil
 	}
@@ -260,7 +260,7 @@ func (r *fsRoot) Lookup(_ context.Context, req *fuse.LookupRequest, resp *fuse.L
 	// Look up instance database version to determine the correct socket path.
 	// Client is nil in unit tests.
 	if r.client != nil {
-		version, err := r.client.InstanceVersion(instance)
+		version, err := r.client.InstanceVersionContext(ctx, instance)
 		if err != nil {
 			return nil, fuse.ENOENT
 		}

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -256,9 +256,8 @@ func isExpired(cfg *tls.Config) bool {
 	return time.Now().After(cfg.Certificates[0].Leaf.NotAfter)
 }
 
-// startRefresh kicks off a refreshCfg asynchronously, returning a channel that is closed
-// when it's complete and updates the cacheEntry when complete. This function should only
-// be called from the scope of "cachedCfg", which controls the logic around throttling refreshes.
+// startRefresh kicks off a refreshCfg asynchronously, that updates the cacheEntry and closes the returned channel once the refresh is completed. This function
+// should only be called from the scope of "cachedCfg", which controls the logic around throttling refreshes.
 func (c *Client) startRefresh(instance string, refreshCfgBuffer time.Duration) chan struct{} {
 	done := make(chan struct{})
 	go func() {

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -286,9 +286,8 @@ func (c *Client) startRefresh(instance string, refreshCfgBuffer time.Duration) c
 		now := time.Now()
 		timeToRefresh := certExpiration.Sub(now) - refreshCfgBuffer
 		if timeToRefresh <= 0 {
-			// If a new certificate expires before our buffer has expired,
-			// we should wait a bit and schedule a new refresh to much closer to the expiration's date
-			// TODO: This situation probably only occurs for Issue #622 - when the oauth2 token isn't refreshed before the cert is
+			// If a new certificate expires before our buffer has expired, we should wait a bit and schedule a new refresh to much closer to the expiration's date
+			// This situation probably only occurs when the oauth2 token isn't refreshed before the cert is, so by scheduling closer to the expriation we can hope the ouath2 token is newer.
 			timeToRefresh = certExpiration.Sub(now) - (5 * time.Second)
 			logging.Errorf("new ephemeral certificate expires sooner than expected (adjusting refresh time to compensate): current time: %v, certificate expires: %v", now, certExpiration)
 		}
@@ -350,7 +349,7 @@ func (c *Client) cachedCfg(instance string) (string, *tls.Config, string, error)
 				e.lastRefreshed = time.Now()
 				c.cfgCache[instance] = e
 			} else {
-				// TODO: Should this be a returned error?
+				// TODO: Investigate returning this as an error instead of just logging
 				logging.Errorf("Throttling refreshCfg(%s): it was only called %v ago", instance, time.Since(e.lastRefreshed))
 			}
 		}

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -79,7 +79,7 @@ func TestContextDialer(t *testing.T) {
 			return nil, errFakeDial
 		},
 		Dialer: func(string, string) (net.Conn, error) {
-			return nil, fmt.Errorf("this dialer should't be used when ContextDialer is set")
+			return nil, fmt.Errorf("this dialer should not be used when ContextDialer is set")
 		},
 	}
 


### PR DESCRIPTION
## Change Description

Expands on the behavior introduced in #666 by reconfiguring the `cachedCfg` function to prevent multiple simultaneous refreshes from occurring at once. 


## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #427 