### PR TITLE
fix: lower refresh buffer and config throttle when IAM authn is enabled

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -554,6 +554,10 @@ func main() {
 	if refreshCfgThrottle < minimumRefreshCfgThrottle {
 		refreshCfgThrottle = minimumRefreshCfgThrottle
 	}
+	refreshCfgBuffer := proxy.DefaultRefreshCfgBuffer
+	if *enableIAMLogin {
+		refreshCfgBuffer = proxy.IAMLoginRefreshCfgBuffer
+	}
 	proxyClient := &proxy.Client{
 		Port:           port,
 		MaxConnections: *maxConnections,
@@ -567,6 +571,7 @@ func main() {
 		}),
 		Conns:              connset,
 		RefreshCfgThrottle: refreshCfgThrottle,
+		RefreshCfgBuffer:   refreshCfgBuffer,
 	}
 
 	// Initialize a source of new connections to Cloud SQL instances.

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -556,6 +556,7 @@ func main() {
 	}
 	refreshCfgBuffer := proxy.DefaultRefreshCfgBuffer
 	if *enableIAMLogin {
+		refreshCfgThrottle = proxy.IAMLoginRefreshThrottle
 		refreshCfgBuffer = proxy.IAMLoginRefreshCfgBuffer
 	}
 	proxyClient := &proxy.Client{

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -32,7 +32,16 @@ import (
 const (
 	DefaultRefreshCfgThrottle = time.Minute
 	keepAlivePeriod           = time.Minute
-	defaultRefreshCfgBuffer   = 5 * time.Minute
+	// DefaultRefreshCfgBuffer is the minimum amount of time for which a
+	// certificate must be valid to ensure the next refresh attempt has adequate
+	// time to complete.
+	DefaultRefreshCfgBuffer = 5 * time.Minute
+	// IAMLoginRefreshCfgBuffer is the minimum amount of a time for which a
+	// certificate holding an Access Token must be valid. Because some token
+	// sources (e.g., ouath2.ComputeTokenSource) are refreshed with only ~60
+	// seconds before expiration, this value must be smaller than the
+	// DefaultRefreshCfgBuffer.
+	IAMLoginRefreshCfgBuffer = 55 * time.Second
 )
 
 var (
@@ -99,8 +108,9 @@ type Client struct {
 	// malfunction.
 	RefreshCfgThrottle time.Duration
 
-	// RefreshCertBuffer is the amount of time before the configuration expires to
-	// attempt to refresh it. If not set, it defaults to 5 minutes.
+	// RefreshCertBuffer is the amount of time before the configuration expires
+	// to attempt to refresh it. If not set, it defaults to 5 minutes. When IAM
+	// Login is enabled, this value should be set to IAMLoginRefreshCfgBuffer.
 	RefreshCfgBuffer time.Duration
 }
 
@@ -172,7 +182,7 @@ func (c *Client) refreshCfg(instance string) (addr string, cfg *tls.Config, vers
 
 	refreshCfgBuffer := c.RefreshCfgBuffer
 	if refreshCfgBuffer == 0 {
-		refreshCfgBuffer = defaultRefreshCfgBuffer
+		refreshCfgBuffer = DefaultRefreshCfgBuffer
 	}
 
 	c.cacheL.Lock()

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -30,13 +30,18 @@ import (
 )
 
 const (
+	// DefaultRefreshCfgThrottle is the time a refresh attempt must wait since
+	// the last attempt.
 	DefaultRefreshCfgThrottle = time.Minute
-	keepAlivePeriod           = time.Minute
+	// IAMLoginRefreshThrottle is the time a refresh attempt must wait since the
+	// last attempt when using IAM login.
+	IAMLoginRefreshThrottle = 30 * time.Second
+	keepAlivePeriod         = time.Minute
 	// DefaultRefreshCfgBuffer is the minimum amount of time for which a
 	// certificate must be valid to ensure the next refresh attempt has adequate
 	// time to complete.
 	DefaultRefreshCfgBuffer = 5 * time.Minute
-	// IAMLoginRefreshCfgBuffer is the minimum amount of a time for which a
+	// IAMLoginRefreshCfgBuffer is the minimum amount of time for which a
 	// certificate holding an Access Token must be valid. Because some token
 	// sources (e.g., ouath2.ComputeTokenSource) are refreshed with only ~60
 	// seconds before expiration, this value must be smaller than the


### PR DESCRIPTION
With IAM login enabled, the proxy would fail to refresh its certificate
when using Application Default Credentials retrieved from the metadata
server. The metadata server returns an access token that is refreshed
only when the expiration is within ~60 seconds. As a result, when the
proxy attempted a refresh of the certificate, it would fail because the
token did not have enough time left on it relative to the default buffer
(i.e., 5 minutes).

This commit configures the buffer to 55 seconds when IAM login is
enabled. When a token has ~60 seconds before expiration, the refresh
logic will schedule a refresh 5 seconds in the future. When 5 seconds
have elapsed, the refresh logic will get a new token whose expiration is
in an hour and restart the clock on the next refresh.

Fixes #662.