### PR TITLE
certs: fix panic on error

### DIFF
--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -202,7 +202,7 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 	if s.EnableIAMLogin {
 		var tokErr error
 		tok, tokErr = s.TokenSource.Token()
-		if err != nil {
+		if tokErr != nil {
 			return tls.Certificate{}, tokErr
 		}
 		// Always refresh the token to ensure its expiration is far enough in


### PR DESCRIPTION
## Change Description

This fixes a nil pointer deref caused by bad error handling in the IAM authentication error path. 

## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)