### PR TITLE
fix: Allow combined use of structured logs and -log_debug_stdout

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -462,7 +462,7 @@ func main() {
 	}
 
 	if *structuredLogs {
-		cleanup, err := logging.EnableStructuredLogs(*logDebugStdout)
+		cleanup, err := logging.EnableStructuredLogs()
 		if err != nil {
 			logging.Errorf("failed to enable structured logs: %v", err)
 			os.Exit(1)

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -462,7 +462,7 @@ func main() {
 	}
 
 	if *structuredLogs {
-		cleanup, err := logging.EnableStructuredLogs()
+		cleanup, err := logging.EnableStructuredLogs(*logDebugStdout)
 		if err != nil {
 			logging.Errorf("failed to enable structured logs: %v", err)
 			os.Exit(1)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -57,8 +57,12 @@ func DisableLogging() {
 
 // EnableStructuredLogs replaces all logging functions with structured logging
 // variants.
-func EnableStructuredLogs() (func(), error) {
-	logger, err := zap.NewProduction()
+func EnableStructuredLogs(logDebugStdout bool) (func(), error) {
+	config := zap.NewProductionConfig()
+	if logDebugStdout {
+		config.OutputPaths = []string{"stdout"}
+	}
+	logger, err := config.Build()
 	if err != nil {
 		return func() {}, err
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -58,7 +58,7 @@ func DisableLogging() {
 
 // EnableStructuredLogs replaces all logging functions with structured logging
 // variants.
-func EnableStructuredLogs() (func(), error) {
+func EnableStructuredLogs(logDebugStdout bool) (func(), error) {
 	// Define level-handling logic.
 	highPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
 		return lvl >= zapcore.ErrorLevel
@@ -67,9 +67,15 @@ func EnableStructuredLogs() (func(), error) {
 		return lvl < zapcore.ErrorLevel
 	})
 
-	// Lock console
-	consoleDebugging := zapcore.Lock(os.Stdout)
+	// Lock consoles
 	consoleErrors := zapcore.Lock(os.Stderr)
+
+	var consoleDebugging zapcore.WriteSyncer
+	if logDebugStdout {
+		consoleDebugging = zapcore.Lock(os.Stdout)
+	} else {
+		consoleDebugging = consoleErrors
+	}
 
 	// Create JSON encoder using opinionated production preset
 	consoleEncoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -59,7 +59,7 @@ func DisableLogging() {
 // EnableStructuredLogs replaces all logging functions with structured logging
 // variants.
 func EnableStructuredLogs(logDebugStdout bool) (func(), error) {
-	// Configuration of zap is based on its Adavnced Configuration example,
+	// Configuration of zap is based on its Advanced Configuration example.
 	// See: https://pkg.go.dev/go.uber.org/zap#example-package-AdvancedConfiguration
 
 	// Define level-handling logic.
@@ -71,7 +71,7 @@ func EnableStructuredLogs(logDebugStdout bool) (func(), error) {
 	})
 
 	// Lock wraps a WriteSyncer in a mutex to make it safe for concurrent use. In
-	// particular, *os.Files must be locked before use.
+	// particular, *os.File types must be locked before use.
 	consoleErrors := zapcore.Lock(os.Stderr)
 	consoleDebugging := consoleErrors
 	if logDebugStdout {
@@ -84,7 +84,7 @@ func EnableStructuredLogs(logDebugStdout bool) (func(), error) {
 		zapcore.NewCore(consoleEncoder, consoleDebugging, lowPriority),
 	)
 
-	// By deafult, caller and stacktrace are not included, so add them here
+	// By default, caller and stacktrace are not included, so add them here
 	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
 
 	sugar := logger.Sugar()


### PR DESCRIPTION
## Change Description

Fix the combined use of structured logs (`-structured_logs`) and standard output debug logs (`-log_debug_stdout`).

## Relevant issues:

- Fixes #725