### PR TITLE
fix: structured logging respects the -verbose flag

### DIFF
--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -462,17 +462,17 @@ func main() {
 		logging.LogDebugToStdout()
 	}
 
+	if !*verbose {
+		logging.LogVerboseToNowhere()
+	}
+
 	if *structuredLogs {
-		cleanup, err := logging.EnableStructuredLogs(*logDebugStdout)
+		cleanup, err := logging.EnableStructuredLogs(*logDebugStdout, *verbose)
 		if err != nil {
 			logging.Errorf("failed to enable structured logs: %v", err)
 			os.Exit(1)
 		}
 		defer cleanup()
-	}
-
-	if !*verbose {
-		logging.LogVerboseToNowhere()
 	}
 
 	if *quiet {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -58,7 +58,7 @@ func DisableLogging() {
 
 // EnableStructuredLogs replaces all logging functions with structured logging
 // variants.
-func EnableStructuredLogs(logDebugStdout bool) (func(), error) {
+func EnableStructuredLogs(logDebugStdout, verbose bool) (func(), error) {
 	// Configuration of zap is based on its Advanced Configuration example.
 	// See: https://pkg.go.dev/go.uber.org/zap#example-package-AdvancedConfiguration
 
@@ -88,7 +88,10 @@ func EnableStructuredLogs(logDebugStdout bool) (func(), error) {
 	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
 
 	sugar := logger.Sugar()
-	Verbosef = sugar.Debugf
+	Verbosef = sugar.Infof
+	if !verbose {
+		Verbosef = noop
+	}
 	Infof = sugar.Infof
 	Errorf = sugar.Errorf
 


### PR DESCRIPTION
Previously, when structured logging was enabled, the code would ignore
the value of the verbose flag. This commit ensures the verbose flag
works with structured logging.

Fixes #727.