### PR TITLE
chore: use version.txt in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X main.metadataString=container" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags \
+    "-X main.metadataString=container -X main.versionString=$(cat version.txt)" \
+    -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final Stage
 FROM gcr.io/distroless/base-debian10:nonroot

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -19,7 +19,9 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X main.metadataString=container.alpine" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags \
+    "-X main.metadataString=container.alpine -X main.versionString=$(cat version.txt)" \
+    -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM alpine:3

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -19,7 +19,9 @@ WORKDIR /go/src/cloudsql-proxy
 COPY . .
 
 RUN go get ./...
-RUN go build -ldflags "-X main.metadataString=container.buster" -o cloud_sql_proxy ./cmd/cloud_sql_proxy
+RUN go build -ldflags \
+    "-X main.metadataString=container.buster -X main.versionString=$(cat version.txt)" \
+    -o cloud_sql_proxy ./cmd/cloud_sql_proxy
 
 # Final stage
 FROM debian:buster

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -263,7 +263,7 @@ Information for all flags:
 var defaultTmp = filepath.Join(os.TempDir(), "cloudsql-proxy-tmp")
 
 // versionString indiciates the version of the proxy currently in use.
-var versionString = "1.22.1-dev"
+var versionString = "development"
 
 // metadataString indiciates additional build or distribution metadata.
 var metadataString = ""


### PR DESCRIPTION
This commit removes the hard-coded version string in cloud_sql_proxy.go
and instead pulls it with a linker flag.