### PR TITLE
chore: update renovate.json to always use Go 1.16

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,10 @@
   "semanticCommits": true,
   "postUpdateOptions": [
     "gomodTidy"
-  ]
+  ],
+  "force": {
+    "constraints": {
+      "go": "1.16"
+    }
+  }
 }


### PR DESCRIPTION
See https://github.com/renovatebot/renovate/issues/6213#issuecomment-816600594 for context.

Also, note: https://github.com/renovatebot/renovate/issues/6213#issuecomment-836869203.