### PR TITLE
fix: strip padding from access tokens if present

### DIFF
--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -227,7 +227,7 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 		if tokErr != nil {
 			return tls.Certificate{}, tokErr
 		}
-
+		// TODO: remove this once issue with OAuth2 Tokens is resolved.
 		trimmedToken := strings.TrimRight(tok.AccessToken, ".")
 		createEphemeralRequest.AccessToken = trimmedToken
 	}

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -227,7 +227,9 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 		if tokErr != nil {
 			return tls.Certificate{}, tokErr
 		}
-		createEphemeralRequest.AccessToken = tok.AccessToken
+
+		trimmedToken := strings.TrimRight(tok.AccessToken, ".")
+		createEphemeralRequest.AccessToken = trimmedToken
 	}
 	req := s.serv.SslCerts.CreateEphemeral(p, regionName, &createEphemeralRequest)
 

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -228,8 +228,8 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 			return tls.Certificate{}, tokErr
 		}
 		// TODO: remove this once issue with OAuth2 Tokens is resolved.
-		trimmedToken := strings.TrimRight(tok.AccessToken, ".")
-		createEphemeralRequest.AccessToken = trimmedToken
+		// See https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/852.
+		createEphemeralRequest.AccessToken = strings.TrimRight(tok.AccessToken, ".")
 	}
 	req := s.serv.SslCerts.CreateEphemeral(p, regionName, &createEphemeralRequest)
 


### PR DESCRIPTION
## Change Description

Strips trailing . characters from access tokens


## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:
- fixes #852