### PR TITLE
fix: use Google Cloud structured log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,13 +276,11 @@ this flag to true.  Defaults to false.
 
 #### `-structured_logs`
 
-Writes all logging output as JSON with the following keys: level, ts, caller,
-msg. For example, the startup message looks like:
+Writes all logging output as JSON with the following keys: severity, timestamp, caller,
+message and optionally stacktrace. For example, the startup message looks like:
 
-```
-{"level":"info","ts":1616014011.8132386,"caller":"cloud_sql_proxy/cloud_sql_proxy.go:510","msg":"Using
-gcloud's active project: [my-project-id]"}
-
+```json
+{"severity":"INFO","timestamp":"2020-10-12T07:20:50.52Z","caller":"cloud_sql_proxy/cloud_sql_proxy.go:510","message":"Using gcloud's active project: [my-project-id]"}
 ```
 
 ## Running as a Kubernetes Sidecar

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -78,12 +78,17 @@ func EnableStructuredLogs(logDebugStdout, verbose bool) (func(), error) {
 		consoleDebugging = zapcore.Lock(os.Stdout)
 	}
 
-	consoleEncoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	config := zap.NewProductionEncoderConfig()
+	config.LevelKey = "severity"
+	config.MessageKey = "message"
+	config.TimeKey = "timestamp"
+	config.EncodeLevel = zapcore.CapitalLevelEncoder
+	config.EncodeTime = zapcore.ISO8601TimeEncoder
+	consoleEncoder := zapcore.NewJSONEncoder(config)
 	core := zapcore.NewTee(
 		zapcore.NewCore(consoleEncoder, consoleErrors, highPriority),
 		zapcore.NewCore(consoleEncoder, consoleDebugging, lowPriority),
 	)
-
 	// By default, caller and stacktrace are not included, so add them here
 	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
 


### PR DESCRIPTION
## Change Description

This fix will generate log messages as json documents that are compatible with [Google Cloud Logging](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields). This fix ensure that Google Cloud Logging will pick up the severity and text message, even if the log is written on stderr.

## Checklist

- [X] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [X] Ensure the tests and linter pass
- [X] Appropriate documentation is updated (if necessary)

There was no test for EnableStructuredLogs() and it is hard to create one. So I left it this way. I did test the flag manually. Given the complexity of the change, I hope this is ok.

## Relevant issues:

- Fixes #860