### PR TITLE
docs: Remove warnings regarding IAM login support for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ When set, the proxy uses this Bearer token for authorization.
 Enables the proxy to use Cloud SQL IAM database authentication. This will cause
 the proxy to use IAM account credentials for database user authentication. For
 details, see [Overview of Cloud SQL IAM database authentication][iam-auth].
-NOTE: This feature only works with Postgres database instances.
 
 ### Connection Flags
 

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -119,7 +119,7 @@ variable for the same effect.`,
 ',', e.g. 'PUBLIC,PRIVATE' `,
 	)
 	// Settings for IAM db proxy authentication
-	enableIAMLogin = flag.Bool("enable_iam_login", false, "Enables database user authentication using Cloud SQL's IAM DB Authentication (Postgres only).")
+	enableIAMLogin = flag.Bool("enable_iam_login", false, "Enables database user authentication using Cloud SQL's IAM DB Authentication.")
 
 	skipInvalidInstanceConfigs = flag.Bool("skip_failed_instance_config", false,
 		`Setting this flag will allow you to prevent the proxy from terminating


### PR DESCRIPTION
IAM login now supported by MySQL, per [docs](https://cloud.google.com/sql/docs/mysql/iam-logins). Also in MySQL documentation: "...we recommend you use the Cloud SQL Auth proxy when using IAM database authentication for long-lived processes or applications that rely on connection pooling."