### PR TITLE
Feature: Integrate generateEphemeralCert and connectSettings api

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ Requires that you configure the Kubernetes container with HTTP probes ([instruct
 
 Specifies the port that the health check server listens and serves on. Defaults to 8090.
 
+#### `-use_sslcerts_api`
+
+Uses ssl certs api instead of connect apis to generate/handle certificates
+
 ## Running as a Kubernetes Sidecar
 
 See the [example here][sidecar-example] as well as [Connecting from Google

--- a/cmd/cloud_sql_proxy/cloud_sql_proxy.go
+++ b/cmd/cloud_sql_proxy/cloud_sql_proxy.go
@@ -136,6 +136,10 @@ unavailable.`,
 	// Settings for healthcheck
 	useHTTPHealthCheck = flag.Bool("use_http_health_check", false, "When set, creates an HTTP server that checks and communicates the health of the proxy client.")
 	healthCheckPort    = flag.String("health_check_port", "8090", "When applicable, health checks take place on this port number. Defaults to 8090.")
+
+	// Settings to use sslCerts apis instead of connect apis
+        useSslCerts = flag.Bool("use_sslcerts_api", false, "When set, sslCerts apis are used instead of connect apis to handle certificates.")
+
 )
 
 const (
@@ -253,7 +257,11 @@ Connection:
     When using Unix sockets (the default for systems which support them), the
     Proxy places the sockets in the directory specified by the -dir parameter.
 
-Automatic instance discovery:
+  -use_sslcerts_api
+   You can use this flag to use sslCerts api to generate/retrieve certificates instead 
+   of the connect apis  
+
+ Automatic instance discovery:
    If the Google Cloud SQL is installed on the local machine and no instance
    connection flags are specified, the proxy connects to all instances in the
    gcloud tool's active project. Run 'gcloud config list project' to
@@ -579,6 +587,7 @@ func main() {
 			IPAddrTypeOpts: ipAddrTypeOptsInput,
 			EnableIAMLogin: *enableIAMLogin,
 			TokenSource:    tokSrc,
+			UseSslCerts: *useSslCerts,
 		}),
 		Conns:              connset,
 		RefreshCfgThrottle: refreshCfgThrottle,

--- a/proxy/certs/certs.go
+++ b/proxy/certs/certs.go
@@ -81,6 +81,9 @@ type RemoteOpts struct {
 	// on the first connection to a database. The default behavior is to generate
 	// the key when the CertSource is created.
 	DelayKeyGenerate bool
+
+	// If set, use ssl certs apis instead of connect apis
+	UseSslCerts bool
 }
 
 // NewCertSourceOpts returns a CertSource configured with the provided Opts.
@@ -120,6 +123,7 @@ func NewCertSourceOpts(c *http.Client, opts RemoteOpts) *RemoteCertSource {
 		IPAddrTypes:    opts.IPAddrTypeOpts,
 		EnableIAMLogin: opts.EnableIAMLogin,
 		TokenSource:    opts.TokenSource,
+		UseSslCerts:    opts.UseSslCerts,
 	}
 	if !opts.DelayKeyGenerate {
 		// Generate the RSA key now, but don't block on it.
@@ -150,6 +154,8 @@ type RemoteCertSource struct {
 	EnableIAMLogin bool
 	// token source for the token information used in cert creation
 	TokenSource oauth2.TokenSource
+	// flag to use sslCerts apis instead of connect apis
+	UseSslCerts bool
 }
 
 // Constants for backoffAPIRetry. These cause the retry logic to scale the
@@ -212,6 +218,9 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 	createEphemeralRequest := sqladmin.SslCertsCreateEphemeralRequest{
 		PublicKey: pubKey,
 	}
+	generateEphemeralCertRequest := sqladmin.GenerateEphemeralCertRequest{
+		PublicKey: pubKey,
+	}
 	var tok *oauth2.Token
 	// If IAM login is enabled, add the OAuth2 token into the ephemeral
 	// certificate request.
@@ -230,11 +239,40 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 		// TODO: remove this once issue with OAuth2 Tokens is resolved.
 		// See https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/852.
 		createEphemeralRequest.AccessToken = strings.TrimRight(tok.AccessToken, ".")
+		generateEphemeralCertRequest.AccessToken = strings.TrimRight(tok.AccessToken,".")
 	}
-	req := s.serv.SslCerts.CreateEphemeral(p, regionName, &createEphemeralRequest)
+	// If UseSslCerts flag is used, use sslCerts apis instead of connect apis
+	if s.UseSslCerts {
+		req := s.serv.SslCerts.CreateEphemeral(p, regionName, &createEphemeralRequest)
+		var data *sqladmin.SslCert
+		err = backoffAPIRetry("createEphemeral for", instance, func() error {
+			data, err = req.Do()
+			return err
+		})
+		if err != nil {
+			return tls.Certificate{}, err
+		}
 
-	var data *sqladmin.SslCert
-	err = backoffAPIRetry("createEphemeral for", instance, func() error {
+		c, err := parseCert(data.Cert)
+		if err != nil {
+			return tls.Certificate{}, fmt.Errorf("couldn't parse ephemeral certificate for instance %q: %v", instance, err)
+		}
+		if s.EnableIAMLogin {
+			// Adjust the certificate's expiration to be the earlier of tok.Expiry or c.NotAfter
+			if tok.Expiry.Before(c.NotAfter) {
+				c.NotAfter = tok.Expiry
+			}
+		}
+		logging.Verbosef("get SSL EphemeralCert successful")
+		return tls.Certificate{
+			Certificate: [][]byte{c.Raw},
+			PrivateKey:  s.generateKey(),
+			Leaf:        c,
+		}, nil
+	} 
+	req := s.serv.Connect.GenerateEphemeralCert(p, regionName, &generateEphemeralCertRequest)
+	var data *sqladmin.GenerateEphemeralCertResponse
+	err = backoffAPIRetry("generateEphemeral for", instance, func() error {
 		data, err = req.Do()
 		return err
 	})
@@ -242,16 +280,18 @@ func (s *RemoteCertSource) Local(instance string) (tls.Certificate, error) {
 		return tls.Certificate{}, err
 	}
 
-	c, err := parseCert(data.Cert)
+	c, err := parseCert(data.EphemeralCert.Cert)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("couldn't parse ephemeral certificate for instance %q: %v", instance, err)
 	}
+
 	if s.EnableIAMLogin {
 		// Adjust the certificate's expiration to be the earlier of tok.Expiry or c.NotAfter
 		if tok.Expiry.Before(c.NotAfter) {
 			c.NotAfter = tok.Expiry
 		}
 	}
+	logging.Verbosef("get Connect SSL EphemeralCert successful")
 	return tls.Certificate{
 		Certificate: [][]byte{c.Raw},
 		PrivateKey:  s.generateKey(),
@@ -282,9 +322,9 @@ func (s *RemoteCertSource) generateKey() *rsa.PrivateKey {
 }
 
 // Find the first matching IP address by user input IP address types
-func (s *RemoteCertSource) findIPAddr(data *sqladmin.DatabaseInstance, instance string) (ipAddrInUse string, err error) {
+func (s *RemoteCertSource) findIPAddr(ipAddresses []*sqladmin.IpMapping, instance string) (ipAddrInUse string, err error) {
 	for _, eachIPAddrTypeByUser := range s.IPAddrTypes {
-		for _, eachIPAddrTypeOfInstance := range data.IpAddresses {
+		for _, eachIPAddrTypeOfInstance := range ipAddresses {
 			if strings.ToUpper(eachIPAddrTypeOfInstance.Type) == strings.ToUpper(eachIPAddrTypeByUser) {
 				ipAddrInUse = eachIPAddrTypeOfInstance.IpAddress
 				return ipAddrInUse, nil
@@ -293,7 +333,7 @@ func (s *RemoteCertSource) findIPAddr(data *sqladmin.DatabaseInstance, instance 
 	}
 
 	ipAddrTypesOfInstance := ""
-	for _, eachIPAddrTypeOfInstance := range data.IpAddresses {
+	for _, eachIPAddrTypeOfInstance := range ipAddresses {
 		ipAddrTypesOfInstance += fmt.Sprintf("(TYPE=%v, IP_ADDR=%v)", eachIPAddrTypeOfInstance.Type, eachIPAddrTypeOfInstance.IpAddress)
 	}
 
@@ -306,32 +346,62 @@ func (s *RemoteCertSource) findIPAddr(data *sqladmin.DatabaseInstance, instance 
 func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr, name, version string, err error) {
 	p, region, n := util.SplitName(instance)
 	regionName := fmt.Sprintf("%s~%s", region, n)
-	req := s.serv.Instances.Get(p, regionName)
+	if s.UseSslCerts {
+		req := s.serv.Instances.Get(p, regionName)
+		var data *sqladmin.DatabaseInstance
+		err = backoffAPIRetry("get instance", instance, func() error {
+			data, err = req.Do()
+			return err
+		})
+		if err != nil {
+			return nil, "", "", "", err
+		}
 
-	var data *sqladmin.DatabaseInstance
+		// TODO(chowski): remove this when us-central is removed.
+		if data.Region == "us-central" {
+			data.Region = "us-central1"
+		}
+		if data.Region != region {
+			if region == "" {
+				err = fmt.Errorf("instance %v doesn't provide region", instance)
+			} else {
+				err = fmt.Errorf(`for connection string "%s": got region %q, want %q`, instance, region, data.Region)
+			}
+			if s.checkRegion {
+				return nil, "", "", "", err
+			}
+			logging.Errorf("%v", err)
+			logging.Errorf("WARNING: specifying the correct region in an instance string will become required in a future version!")
+		}
+
+		if len(data.IpAddresses) == 0 {
+			return nil, "", "", "", fmt.Errorf("no IP address found for %v", instance)
+		}
+		if data.BackendType == "FIRST_GEN" {
+			logging.Errorf("WARNING: proxy client does not support first generation Cloud SQL instances.")
+			return nil, "", "", "", fmt.Errorf("%q is a first generation instance", instance)
+		}
+
+		// Find the first matching IP address by user input IP address types
+		ipAddrInUse := ""
+		ipAddrInUse, err = s.findIPAddr(data.IpAddresses, instance)
+		if err != nil {
+			return nil, "", "", "", err
+		}
+		c, err := parseCert(data.ServerCaCert.Cert)
+
+		return c, ipAddrInUse, p + ":" + n, data.DatabaseVersion, err
+
+	} 
+
+	req := s.serv.Connect.Get(p, regionName)	
+	var data *sqladmin.ConnectSettings
 	err = backoffAPIRetry("get instance", instance, func() error {
 		data, err = req.Do()
 		return err
 	})
 	if err != nil {
 		return nil, "", "", "", err
-	}
-
-	// TODO(chowski): remove this when us-central is removed.
-	if data.Region == "us-central" {
-		data.Region = "us-central1"
-	}
-	if data.Region != region {
-		if region == "" {
-			err = fmt.Errorf("instance %v doesn't provide region", instance)
-		} else {
-			err = fmt.Errorf(`for connection string "%s": got region %q, want %q`, instance, region, data.Region)
-		}
-		if s.checkRegion {
-			return nil, "", "", "", err
-		}
-		logging.Errorf("%v", err)
-		logging.Errorf("WARNING: specifying the correct region in an instance string will become required in a future version!")
 	}
 
 	if len(data.IpAddresses) == 0 {
@@ -344,7 +414,7 @@ func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr
 
 	// Find the first matching IP address by user input IP address types
 	ipAddrInUse := ""
-	ipAddrInUse, err = s.findIPAddr(data, instance)
+	ipAddrInUse, err = s.findIPAddr(data.IpAddresses, instance)
 	if err != nil {
 		return nil, "", "", "", err
 	}
@@ -352,4 +422,5 @@ func (s *RemoteCertSource) Remote(instance string) (cert *x509.Certificate, addr
 	c, err := parseCert(data.ServerCaCert.Cert)
 
 	return c, ipAddrInUse, p + ":" + n, data.DatabaseVersion, err
+
 }


### PR DESCRIPTION
## Change Description

- Integrate two new connect apis [generateEphemeralCert](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/connect/generateEphemeralCert) and [connect Settings](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/connect/get).
- Introduce flag --use_sslcerts_api to make the change backward compatible. If the flag is set, the sslCerts apis are used instead of connect apis to generate/retrieve certificates


## Checklist

- [X] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [X] Ensure the tests and linter pass
- [X] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #<issue_number_goes_here>