### PR TITLE
fix: refactor client test

### DIFF
--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -318,17 +318,16 @@ func TestRemoteCertError(t *testing.T) {
 
 }
 
-func TestValidate(t *testing.T) {
+func TestParseInstanceConnectionName(t *testing.T) {
 	// SplitName has its own tests and is not specifically tested here.
 	table := []struct {
 		in           string
-		wantValid    bool
 		wantErrorStr string
 	}{
-		{"proj:region:my-db", true, ""},
-		{"proj:region:my-db=options", true, ""},
-		{"proj=region=my-db", false, "invalid instance argument: must be either form - `<instance_connection_string>` or `<instance_connection_string>=<options>`; invalid arg was \"proj=region=my-db\""},
-		{"projregionmy-db", false, "invalid instance connection string: must be in the form `project:region:instance-name`; invalid name was \"projregionmy-db\""},
+		{"proj:region:my-db", ""},
+		{"proj:region:my-db=options", ""},
+		{"proj=region=my-db", "invalid instance argument: must be either form - `<instance_connection_string>` or `<instance_connection_string>=<options>`; invalid arg was \"proj=region=my-db\""},
+		{"projregionmy-db", "invalid instance connection string: must be in the form `project:region:instance-name`; invalid name was \"projregionmy-db\""},
 	}
 
 	for _, test := range table {
@@ -338,7 +337,7 @@ func TestValidate(t *testing.T) {
 			gotErrorStr = gotError.Error()
 		}
 		if gotErrorStr != test.wantErrorStr {
-			t.Errorf("Validate(%q): got \"%v\" for error, want \"%v\"", test.in, gotError, test.wantErrorStr)
+			t.Errorf("ParseInstanceConnectionName(%q): got \"%v\" for error, want \"%v\"", test.in, gotErrorStr, test.wantErrorStr)
 		}
 	}
 }


### PR DESCRIPTION
## Change Description

Renames TestValidate to TestParseInstanceConnectionName; removes wantValid from the table definition.
