### PR TITLE
chore: make fuse tests reliable

### DIFF
--- a/proxy/fuse/fuse_test.go
+++ b/proxy/fuse/fuse_test.go
@@ -83,7 +83,7 @@ func TestReadme(t *testing.T) {
 	}
 	defer fuse.Close()
 
-	data, err := os.ReadFile(filepath.Join(dir, "README"))
+	data, err := ioutil.ReadFile(filepath.Join(dir, "README"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func BenchmarkNewConnection(b *testing.B) {
 			b.Errorf("couldn't dial: %v", err)
 		}
 
-		data, err := io.ReadAll(c)
+		data, err := ioutil.ReadAll(c)
 		if err != nil {
 			b.Errorf("got read error: %v", err)
 		} else if got := string(data); got != want {

--- a/proxy/fuse/fuse_test.go
+++ b/proxy/fuse/fuse_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -28,8 +27,6 @@ import (
 	"syscall"
 	"testing"
 	"time"
-
-	"bazil.org/fuse"
 )
 
 func randTmpDir() string {
@@ -224,21 +221,4 @@ func BenchmarkNewConnection(b *testing.B) {
 	if incomingCount != b.N {
 		b.Fatalf("got %d connections, want %d", incomingCount, b.N)
 	}
-}
-
-func TestMain(m *testing.M) {
-	dir := randTmpDir()
-	// Unmount before the tests start, else they won't work correctly.
-	if err := fuse.Unmount(dir); err != nil {
-		log.Printf("TestMain: couldn't unmount fuse directory %q: %v", dir, err)
-	}
-
-	ret := m.Run()
-	// Make sure to unmount at the end, so that we don't leave the system in an
-	// inconsistent state in case something weird happened.
-	if err := fuse.Unmount(dir); err != nil {
-		log.Printf("TestMain: couldn't unmount fuse directory %q: %v", dir, err)
-	}
-
-	os.Exit(ret)
 }

--- a/proxy/fuse/fuse_test.go
+++ b/proxy/fuse/fuse_test.go
@@ -29,10 +29,12 @@ import (
 	"time"
 )
 
-func randTmpDir() string {
+func randTmpDir(t interface {
+	Fatalf(format string, args ...interface{})
+}) string {
 	name, err := ioutil.TempDir("", "*")
 	if err != nil {
-		panic(err)
+		t.Fatalf("failed to create tmp dir: %v", err)
 	}
 	return name
 }
@@ -55,8 +57,8 @@ func tryFunc(f func() error, maxCount int) error {
 }
 
 func TestFuseClose(t *testing.T) {
-	dir := randTmpDir()
-	tmpdir := randTmpDir()
+	dir := randTmpDir(t)
+	tmpdir := randTmpDir(t)
 	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -72,8 +74,8 @@ func TestFuseClose(t *testing.T) {
 
 // TestBadDir verifies that the fuse module does not create directories, only simple files.
 func TestBadDir(t *testing.T) {
-	dir := randTmpDir()
-	tmpdir := randTmpDir()
+	dir := randTmpDir(t)
+	tmpdir := randTmpDir(t)
 	_, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -94,8 +96,8 @@ func TestBadDir(t *testing.T) {
 }
 
 func TestReadme(t *testing.T) {
-	dir := randTmpDir()
-	tmpdir := randTmpDir()
+	dir := randTmpDir(t)
+	tmpdir := randTmpDir(t)
 	_, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -116,8 +118,8 @@ func TestReadme(t *testing.T) {
 }
 
 func TestSingleInstance(t *testing.T) {
-	dir := randTmpDir()
-	tmpdir := randTmpDir()
+	dir := randTmpDir(t)
+	tmpdir := randTmpDir(t)
 	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -174,8 +176,8 @@ func TestSingleInstance(t *testing.T) {
 }
 
 func BenchmarkNewConnection(b *testing.B) {
-	dir := randTmpDir()
-	tmpdir := randTmpDir()
+	dir := randTmpDir(b)
+	tmpdir := randTmpDir(b)
 	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
 	if err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
The fuse tests were unreliable for two reasons:
1. All tests used the same two directories to mount and unmount FUSE file systems, and
2. The FUSE mount takes some amount of time, so promptly trying to close the connection was subject to race conditions.

This PR addresses both issues:
1. It uses distinct directories for each test, and
2. It attempts to close the connection at most 10 times before failing.

I've manually run the tests 15 times to verify (at least by best effort) that this fix does in fact work.

Fixes #856