### PR TITLE
Mysql is also supported in gcloud IAM auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ When set, the proxy uses this Bearer token for authorization.
 Enables the proxy to use Cloud SQL IAM database authentication. This will cause
 the proxy to use IAM account credentials for database user authentication. For
 details, see [Overview of Cloud SQL IAM database authentication][iam-auth].
-NOTE: This feature only works with Postgres database instances.
+NOTE: This feature only works with Postgres and Mysql database instances.
 
 ### Connection Flags
 


### PR DESCRIPTION
## Mysql is also supported now in gcloud IAM database authentication

Adding Mysql in readme Note to let others know that Mysql is also supported with flag `-enable_iam_login`.
https://cloud.google.com/sql/docs/mysql/authentication
It works exactly similar to Postgres so no other documentation is required.


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/903) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #903