### PR TITLE
docs: suggest macfuse over osxfuse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ sudo apt-get install fuse
 On macOS, use:
 
 ```
-brew install --cask osxfuse
+brew install --cask macfuse
 ```
 
 ### How to run just unit tests


### PR DESCRIPTION
This is probably the preferred option for macOS 12.0 and M1 chips. 

I noticed that the kokoro build is also installing `osxfuse`, but am unaware of what version of macOS it might be using (not a Googler).