### PR TITLE
chore: skip fuse tests with `go test -short`

### DIFF
--- a/cmd/cloud_sql_proxy/proxy_test.go
+++ b/cmd/cloud_sql_proxy/proxy_test.go
@@ -96,6 +96,9 @@ func TestCreateInstanceConfigs(t *testing.T) {
 		if runtime.GOOS == "windows" && !v.supportedOnWindows {
 			continue
 		}
+		if v.useFuse && testing.Short() {
+			t.Skip("skipping fuse tests in short mode.")
+		}
 		_, err := CreateInstanceConfigs(v.dir, v.useFuse, v.instances, v.instancesSrc, mockClient, v.skipFailedInstanceConfig)
 		if v.wantErr {
 			if err == nil {

--- a/proxy/fuse/fuse_linux_test.go
+++ b/proxy/fuse/fuse_linux_test.go
@@ -25,6 +25,10 @@ import (
 )
 
 func TestFUSESupport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fuse tests in short mode.")
+	}
+
 	removePath := func() func() {
 		original := os.Getenv("PATH")
 		os.Unsetenv("PATH")

--- a/proxy/fuse/fuse_test.go
+++ b/proxy/fuse/fuse_test.go
@@ -58,6 +58,10 @@ func tryFunc(f func() error, maxCount int) error {
 }
 
 func TestFuseClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fuse tests in short mode.")
+	}
+
 	dir := randTmpDir(t)
 	tmpdir := randTmpDir(t)
 	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
@@ -75,6 +79,10 @@ func TestFuseClose(t *testing.T) {
 
 // TestBadDir verifies that the fuse module does not create directories, only simple files.
 func TestBadDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fuse tests in short mode.")
+	}
+
 	dir := randTmpDir(t)
 	tmpdir := randTmpDir(t)
 	_, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
@@ -97,6 +105,10 @@ func TestBadDir(t *testing.T) {
 }
 
 func TestReadme(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fuse tests in short mode.")
+	}
+
 	dir := randTmpDir(t)
 	tmpdir := randTmpDir(t)
 	_, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
@@ -119,6 +131,10 @@ func TestReadme(t *testing.T) {
 }
 
 func TestSingleInstance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fuse tests in short mode.")
+	}
+
 	dir := randTmpDir(t)
 	tmpdir := randTmpDir(t)
 	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)
@@ -177,6 +193,10 @@ func TestSingleInstance(t *testing.T) {
 }
 
 func BenchmarkNewConnection(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping fuse tests in short mode.")
+	}
+
 	dir := randTmpDir(b)
 	tmpdir := randTmpDir(b)
 	src, fuse, err := NewConnSrc(dir, tmpdir, nil, nil)


### PR DESCRIPTION
## Change Description

Allows the skipping of all fuse related tests with the short command, provided by go test.

Other package managers (nix, brew, etc) may want to build and test `cloud_sql_proxy` themselves. The fuse tests require external binaries with hardcoded paths in order to run. This is currently unworkable in nixpkgs.

## Checklist

- [ ] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [ ] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #<issue_number_goes_here>