### PR TITLE
fix: improve logging and cleanup

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -34,9 +33,6 @@ type proxyClient struct {
 
 	// mnts is a list of all mounted sockets for this client
 	mnts []*socketMount
-	// serveCtx is used for serving data
-	serveCtx    context.Context
-	serveCancel context.CancelFunc
 }
 
 // newProxyClient completes the initial setup required to get the proxy to a "steady" state.
@@ -49,7 +45,7 @@ func newProxyClient(ctx context.Context, cmd *cobra.Command, args []string) (*pr
 
 	port := 5000 // TODO: figure out better port allocation strategy
 	for i, inst := range args {
-		m := newSocketMount(dialer, inst)
+		m := &socketMount{inst: inst}
 		addr, err := m.listen(ctx, "tcp4", net.JoinHostPort("127.0.0.1", fmt.Sprint(port+i)))
 		if err != nil {
 			return nil, fmt.Errorf("[%s] Unable to mount socket: %v", inst, err)
@@ -63,12 +59,13 @@ func newProxyClient(ctx context.Context, cmd *cobra.Command, args []string) (*pr
 
 // serve listens on the mounted ports and beging proxying the connections to the instances.
 func (pc *proxyClient) serve(ctx context.Context) error {
-	pc.serveCtx, pc.serveCancel = context.WithCancel(ctx)
-	defer pc.serveCancel()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	exitCh := make(chan error)
+	defer close(exitCh)
 	for _, m := range pc.mnts {
 		go func(mnt *socketMount) {
-			err := mnt.serve(ctx)
+			err := pc.serveSocketMount(ctx, mnt)
 			if err != nil {
 				exitCh <- err
 				return
@@ -81,27 +78,52 @@ func (pc *proxyClient) serve(ctx context.Context) error {
 // close triggers the proxyClient to shutdown.
 func (pc *proxyClient) close() {
 	defer pc.dialer.Close()
-	defer pc.serveCancel()
 	for _, m := range pc.mnts {
 		m.close()
+	}
+}
+
+// serveSocketMount persistently listens to the socketMounts listener and proxies connections to a
+// given Cloud SQL instance.
+func (pc *proxyClient) serveSocketMount(ctx context.Context, s *socketMount) error {
+	if s.listener == nil {
+		return fmt.Errorf("[%s] mount doesn't have a listener set", s.inst)
+	}
+	for {
+		cConn, err := s.listener.Accept()
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+				pc.cmd.PrintErrf("[%s] Error accepting connection: %v\n", s.inst, err)
+				// For transient errors, wait a small amount of time to see if it resolves itself
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+		// handle the connection in a separate goroutine
+		go func() {
+			pc.cmd.Printf("[%s] accepted connection from %s\n", s.inst, cConn.RemoteAddr())
+
+			// give a max of 30 seconds to connect to the instance
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			sConn, err := pc.dialer.Dial(ctx, s.inst)
+			if err != nil {
+				pc.cmd.Printf("[%s] failed to connect to instance: %v\n", s.inst, err)
+				cConn.Close()
+				return
+			}
+			pc.proxyConn(s.inst, cConn, sConn)
+		}()
 	}
 }
 
 // socketMount is a tcp/unix socket that listens for a Cloud SQL instance. It should
 // only be created with newSocketMount.
 type socketMount struct {
-	dialer *cloudsqlconn.Dialer
-	inst   string
-
+	inst     string
 	listener net.Listener
-}
-
-// newSocketMount creates a new socketMount struct for a specific Cloud SQL instance.
-func newSocketMount(dialer *cloudsqlconn.Dialer, inst string) *socketMount {
-	return &socketMount{
-		dialer: dialer,
-		inst:   inst,
-	}
 }
 
 // listen causes a socketMount to create a Listener at the specified network address.
@@ -115,37 +137,6 @@ func (s *socketMount) listen(ctx context.Context, network string, host string) (
 	return s.listener.Addr(), nil
 }
 
-// serve persistently listens to the socketMounts listener and proxies connections to a
-// given Cloud SQL instance.
-func (s *socketMount) serve(ctx context.Context) error {
-	if s.listener == nil {
-		return fmt.Errorf("[%s] mount doesn't have a listener set", s.inst)
-	}
-	for {
-		cConn, err := s.listener.Accept()
-		if err != nil {
-			log.Printf("[%s] Error accepting connection: %v\n", s.inst, err)
-			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-				// For transient errors, wait a small amount of time to see if it resolves itself
-				time.Sleep(10 * time.Millisecond)
-				continue
-			}
-			return err
-		}
-		// handle the connection in a separate goroutine
-		go func() {
-			log.Printf("[%s] accepted connection from %s\n", s.inst, cConn.RemoteAddr())
-			sConn, err := s.dialer.Dial(ctx, s.inst)
-			if err != nil {
-				log.Printf("[%s] failed to connect to instance: %v\n", s.inst, err)
-				cConn.Close()
-				return
-			}
-			proxyConn(s.inst, cConn, sConn)
-		}()
-	}
-}
-
 // close stops the mount from listening for any more connections
 func (s *socketMount) close() error {
 	err := s.listener.Close()
@@ -154,14 +145,18 @@ func (s *socketMount) close() error {
 }
 
 // proxyConn sets up a bidirectional copy between two open connections
-func proxyConn(inst string, client, server net.Conn) {
+func (pc *proxyClient) proxyConn(inst string, client, server net.Conn) {
 	// only allow the first side to give an error for terminating a connection
 	var o sync.Once
-	cleanup := func(errDesc string) {
+	cleanup := func(errDesc string, isErr bool) {
 		o.Do(func() {
-			log.Printf(errDesc + "\n")
 			client.Close()
 			server.Close()
+			if isErr {
+				pc.cmd.PrintErrln(errDesc)
+			} else {
+				pc.cmd.Println(errDesc)
+			}
 		})
 	}
 
@@ -176,16 +171,16 @@ func proxyConn(inst string, client, server net.Conn) {
 			}
 			switch {
 			case cErr == io.EOF:
-				cleanup(fmt.Sprintf("[%s] client closed the connection", inst))
+				cleanup(fmt.Sprintf("[%s] client closed the connection", inst), false)
 				return
 			case cErr != nil:
-				cleanup(fmt.Sprintf("[%s] connection aborted - error reading from client: %v", inst, cErr))
+				cleanup(fmt.Sprintf("[%s] connection aborted - error reading from client: %v", inst, cErr), true)
 				return
 			case sErr == io.EOF:
-				cleanup(fmt.Sprintf("[%s] instance closed the connection", inst))
+				cleanup(fmt.Sprintf("[%s] instance closed the connection", inst), false)
 				return
 			case sErr != nil:
-				cleanup(fmt.Sprintf("[%s] connection aborted - error writing to instance: %v", inst, cErr))
+				cleanup(fmt.Sprintf("[%s] connection aborted - error writing to instance: %v", inst, cErr), true)
 				return
 			}
 		}
@@ -201,16 +196,16 @@ func proxyConn(inst string, client, server net.Conn) {
 		}
 		switch {
 		case sErr == io.EOF:
-			cleanup(fmt.Sprintf("[%s] instance closed the connection", inst))
+			cleanup(fmt.Sprintf("[%s] instance closed the connection", inst), false)
 			return
 		case sErr != nil:
-			cleanup(fmt.Sprintf("[%s] connection aborted - error reading from instance: %v", inst, sErr))
+			cleanup(fmt.Sprintf("[%s] connection aborted - error reading from instance: %v", inst, sErr), true)
 			return
 		case cErr == io.EOF:
-			cleanup(fmt.Sprintf("[%s] client closed the connection", inst))
+			cleanup(fmt.Sprintf("[%s] client closed the connection", inst), false)
 			return
 		case cErr != nil:
-			cleanup(fmt.Sprintf("[%s] connection aborted - error writing to client: %v", inst, sErr))
+			cleanup(fmt.Sprintf("[%s] connection aborted - error writing to client: %v", inst, sErr), true)
 			return
 		}
 	}


### PR DESCRIPTION
## Change Description

Update it so we're using `cmd.Print...` everywhere over `log.Print...`, and cleaning up some roughly related cleanup. 
