### PR TITLE
fix: invalidated config should retain error

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -526,7 +526,7 @@ func (c *Client) selectDialer() func(context.Context, string, string) (net.Conn,
 	}
 }
 
-func (c *Client) invalidateCfg(cfg *tls.Config, instance string) {
+func (c *Client) invalidateCfg(cfg *tls.Config, instance string, err error) {
 	c.cacheL.RLock()
 	e := c.cfgCache[instance]
 	c.cacheL.RUnlock()
@@ -541,6 +541,7 @@ func (c *Client) invalidateCfg(cfg *tls.Config, instance string) {
 		return
 	}
 	c.cfgCache[instance] = cacheEntry{
+		err:           err,
 		done:          e.done,
 		lastRefreshed: e.lastRefreshed,
 	}

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -540,6 +540,7 @@ func (c *Client) invalidateCfg(cfg *tls.Config, instance string, err error) {
 	if e.cfg != cfg {
 		return
 	}
+	err = fmt.Errorf("config invalidated after TLS handshake failed, error = %w", err)
 	c.cfgCache[instance] = cacheEntry{
 		err:           err,
 		done:          e.done,

--- a/proxy/proxy/client_test.go
+++ b/proxy/proxy/client_test.go
@@ -531,9 +531,9 @@ func TestClientHandshakeCanceled(t *testing.T) {
 			if gotLen := len(invalid); gotLen != 1 {
 				t.Fatalf("invalid instance want = 1, got = %v", gotLen)
 			}
-			i := invalid[0]
-			if want := "deadline exceeded"; !strings.Contains(i.err.Error(), want) {
-				t.Fatalf("invalid instance error want = %v, got = %v", want, i.Error())
+			got := invalid[0]
+			if got.err == nil {
+				t.Fatal("want invalid instance error, got nil")
 			}
 		})
 	})

--- a/proxy/proxy/connect_tls_117.go
+++ b/proxy/proxy/connect_tls_117.go
@@ -38,7 +38,7 @@ func (c *Client) connectTLS(
 	// this file is conditionally compiled on only Go versions >= 1.17.
 	if err := ret.HandshakeContext(ctx); err != nil {
 		_ = ret.Close()
-		c.invalidateCfg(cfg, instance)
+		c.invalidateCfg(cfg, instance, err)
 		return nil, err
 	}
 	return ret, nil

--- a/proxy/proxy/connect_tls_117.go
+++ b/proxy/proxy/connect_tls_117.go
@@ -20,6 +20,7 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 )
 
@@ -38,6 +39,7 @@ func (c *Client) connectTLS(
 	// this file is conditionally compiled on only Go versions >= 1.17.
 	if err := ret.HandshakeContext(ctx); err != nil {
 		_ = ret.Close()
+		err = fmt.Errorf("config invalidated after TLS handshake failed, error = %w", err)
 		c.invalidateCfg(cfg, instance, err)
 		return nil, err
 	}

--- a/proxy/proxy/connect_tls_117.go
+++ b/proxy/proxy/connect_tls_117.go
@@ -20,7 +20,6 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 )
 
@@ -39,7 +38,6 @@ func (c *Client) connectTLS(
 	// this file is conditionally compiled on only Go versions >= 1.17.
 	if err := ret.HandshakeContext(ctx); err != nil {
 		_ = ret.Close()
-		err = fmt.Errorf("config invalidated after TLS handshake failed, error = %w", err)
 		c.invalidateCfg(cfg, instance, err)
 		return nil, err
 	}

--- a/proxy/proxy/connect_tls_other.go
+++ b/proxy/proxy/connect_tls_other.go
@@ -20,6 +20,7 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"sync"
 	"time"

--- a/proxy/proxy/connect_tls_other.go
+++ b/proxy/proxy/connect_tls_other.go
@@ -20,7 +20,6 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 	"sync"
 	"time"

--- a/proxy/proxy/connect_tls_other.go
+++ b/proxy/proxy/connect_tls_other.go
@@ -106,7 +106,7 @@ func (c *Client) connectTLS(
 	ret := tls.Client(conn, cfg)
 	if err := ret.Handshake(); err != nil {
 		_ = ret.Close()
-		c.invalidateCfg(cfg, instance)
+		c.invalidateCfg(cfg, instance, err)
 		return nil, err
 	}
 	return ret, nil

--- a/proxy/proxy/connect_tls_other.go
+++ b/proxy/proxy/connect_tls_other.go
@@ -107,7 +107,6 @@ func (c *Client) connectTLS(
 	ret := tls.Client(conn, cfg)
 	if err := ret.Handshake(); err != nil {
 		_ = ret.Close()
-		err = fmt.Errorf("config invalidated after TLS handshake failed, error = %w", err)
 		c.invalidateCfg(cfg, instance, err)
 		return nil, err
 	}

--- a/proxy/proxy/connect_tls_other.go
+++ b/proxy/proxy/connect_tls_other.go
@@ -106,6 +106,7 @@ func (c *Client) connectTLS(
 	ret := tls.Client(conn, cfg)
 	if err := ret.Handshake(); err != nil {
 		_ = ret.Close()
+		err = fmt.Errorf("config invalidated after TLS handshake failed, error = %w", err)
 		c.invalidateCfg(cfg, instance, err)
 		return nil, err
 	}


### PR DESCRIPTION
When a TLS handshake fails, the client would invalidate the
configuration without recording the associated error. When the liveness
check runs, it would panic when trying to print the invalidated
configuration's error because the error was nil. This commit ensures
that when the proxy invalidates a configuration, it includes the error.

Fixes #1065.