### PR TITLE
chore: stop updating google.golang.org/api

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
     "gomodTidy"
   ],
   "ignoreDeps": [
-      "golang.org/x/net"
+    "golang.org/x/net",
+    "google.golang.org/api"
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
As of https://github.com/googleapis/google-api-go-client/pull/1428 and v0.69.0, the minimum Go version is Go 1.15.