### PR TITLE
docs: enable_iam_login works with MySQL (#1106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ When set, the proxy uses this Bearer token for authorization.
 Enables the proxy to use Cloud SQL IAM database authentication. This will cause
 the proxy to use IAM account credentials for database user authentication. For
 details, see [Overview of Cloud SQL IAM database authentication][iam-auth].
-NOTE: This feature only works with Postgres database instances.
 
 ### Connection Flags
 


### PR DESCRIPTION
enable_iam_login working fine with MySQL. Verified on production.

Ref.: https://cloud.google.com/sql/docs/mysql/authentication

## Change Description

Removed "NOTE: This feature only works with Postgres database instances."