### PR TITLE
feat: add Go version support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,11 @@ supported for 1 year.
 **Unsupported** - Any major version that has been deprecated for >=1 year is
 considered publicly unsupported.
 
+### Supported Go Versions
+
+We test and support at least the latest 3 Go versions. Changes in supported Go 
+versions will be considered a minor change, and will be noted in the release notes. 
+
 ### Release cadence
 The Cloud SQL Auth proxy aims for a minimum monthly release cadence. If no new
 features or fixes have been added, a new PATCH version with the latest


### PR DESCRIPTION
Alternative to https://github.com/GoogleCloudPlatform/cloudsql-proxy/pull/1104