### PR TITLE
fix: don't send on a closed channel

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -67,7 +67,11 @@ func (pc *proxyClient) serve(ctx context.Context) error {
 			err := pc.serveSocketMount(ctx, mnt)
 			if err != nil {
 				select {
-				// Best effort attempt to send error
+				// Best effort attempt to send error.
+				// If this send fails, it means the reading goroutine has
+				// already pulled a value out of the channel and is no longer
+				// reading any more values. In other words, we report only the
+				// first error.
 				case exitCh <- err:
 				default:
 					return


### PR DESCRIPTION
When lauching the proxy with multiple instances, a second goroutine
would attempt to send on a closed channel. This commit resolves the
problem by leaving the channel open and preventing a goroutine leak by
attempting a best effort send.