### PR TITLE
fix: make URL parsing test work with Go 1.16

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -149,7 +149,7 @@ func TestNewCommandWithErrors(t *testing.T) {
 		},
 		{
 			desc: "when the query string is bogus",
-			args: []string{"proj:region:inst?ke;y=b;ad"},
+			args: []string{"proj:region:inst?%=foo"},
 		},
 		{
 			desc: "when the address query param is empty",


### PR DESCRIPTION
From the release notes in Go 1.17:

The net/url and net/http packages used to accept ";" (semicolon) as a
setting separator in URL queries, in addition to "&" (ampersand). Now,
settings with non-percent-encoded semicolons are rejected and net/http
servers will log a warning to Server.ErrorLog when encountering one in a
request URL.

See "URL query parsing" in https://go.dev/doc/go1.17.