### PR TITLE
chore: round timeToRefresh for logging.

### DIFF
--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -317,7 +317,7 @@ func (c *Client) startRefresh(instance string, refreshCfgBuffer time.Duration) c
 			timeToRefresh = certExpiration.Sub(now) - (5 * time.Second)
 			logging.Errorf("new ephemeral certificate expires sooner than expected (adjusting refresh time to compensate): current time: %v, certificate expires: %v", now, certExpiration)
 		}
-		logging.Infof("Scheduling refresh of ephemeral certificate in %s", timeToRefresh)
+		logging.Infof("Scheduling refresh of ephemeral certificate in %s", timeToRefresh.Round(time.Millisecond))
 		go c.refreshCertAfter(instance, timeToRefresh)
 	}()
 	return done

--- a/proxy/proxy/client.go
+++ b/proxy/proxy/client.go
@@ -317,7 +317,7 @@ func (c *Client) startRefresh(instance string, refreshCfgBuffer time.Duration) c
 			timeToRefresh = certExpiration.Sub(now) - (5 * time.Second)
 			logging.Errorf("new ephemeral certificate expires sooner than expected (adjusting refresh time to compensate): current time: %v, certificate expires: %v", now, certExpiration)
 		}
-		logging.Infof("Scheduling refresh of ephemeral certificate in %s", timeToRefresh.Round(time.Millisecond))
+		logging.Infof("Scheduling refresh of ephemeral certificate in %s", timeToRefresh.Round(time.Second))
 		go c.refreshCertAfter(instance, timeToRefresh)
 	}()
 	return done


### PR DESCRIPTION
Log the time duration for re-scheduling the refresh of ephemeral certificate rounded to milliseconds.

Right now, logging the current left duration for refresh is quite verbose. For instance, the message I see logged on my console why I try to connect to one instance is: `Scheduling refresh of ephemeral certificate in 54m59.294191713s`. I feel that this contains a little bit too much details. Rounding the timeToRefresh value during logging to ensure per-millisecond granularity should be good enough.