### PR TITLE
chore(ci): add label trigger to lint action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,3 +39,19 @@ jobs:
     - run: go mod tidy
     - name: Verify no changes from goimports and go mod tidy. If you're reading this and the check has failed, run `goimports -w . && go mod tidy`.
       run: git diff --exit-code
+    - name: Test Remove Label
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          try {
+            await github.rest.issues.removeLabel({
+              name: 'lint:run',
+              owner: 'GoogleCloudPlatform',
+              repo: 'cloudsql-proxy',
+              issue_number: context.payload.pull_request.number
+            });
+          } catch (e) {
+            console.log(e)
+            console.log("Could not remove label!")
+          }

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 name: lint
-on: [pull_request]
+on: 
+  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
-  lint:
+  lint:  
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     name: run lint
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +32,9 @@ jobs:
       run: go get golang.org/x/tools/cmd/goimports
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
     - run: goimports -w .
     - run: go mod tidy
     - name: Verify no changes from goimports and go mod tidy. If you're reading this and the check has failed, run `goimports -w . && go mod tidy`.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,7 +39,8 @@ jobs:
     - run: go mod tidy
     - name: Verify no changes from goimports and go mod tidy. If you're reading this and the check has failed, run `goimports -w . && go mod tidy`.
       run: git diff --exit-code
-    - name: Test Remove Label
+    - name: Remove PR Label
+      if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,6 +53,5 @@ jobs:
               issue_number: context.payload.pull_request.number
             });
           } catch (e) {
-            console.log(e)
-            console.log("Could not remove label!")
+            console.log('Failed to remove label. Another job may have already removed it!');
           }

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,7 +46,7 @@ jobs:
         script: |
           try {
             await github.rest.issues.removeLabel({
-              name: 'lint:run',
+              name: 'lint: run',
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,7 +46,7 @@ jobs:
         script: |
           try {
             await github.rest.issues.removeLabel({
-              name: 'lint: run',
+              name: 'tests: run',
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,8 +47,8 @@ jobs:
           try {
             await github.rest.issues.removeLabel({
               name: 'lint:run',
-              owner: 'GoogleCloudPlatform',
-              repo: 'cloudsql-proxy',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               issue_number: context.payload.pull_request.number
             });
           } catch (e) {


### PR DESCRIPTION
Enabling lint job to be triggered by `tests: run` label on PRs.