### PR TITLE
chore(ci): apply "tests: run" to trusted contributors

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,15 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+disabled: true

--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -12,4 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-disabled: true
+annotations:
+  - type: label
+    text: "tests: run"


### PR DESCRIPTION
Now that kokoro builds have been removed there is no need for the `kokoro:force-run` label to be auto-applied by the [trusted-contribution](https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution) bot on PRs.

Instead PRs from `renovate-bot` etc. should apply `tests: run` label instead.