### PR TITLE
chore(ci): enable Github Actions tests on v2

### DIFF
--- a/.github/workflows/v2-periodic.yaml
+++ b/.github/workflows/v2-periodic.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,22 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: tests
+name: v2 periodic
 on:
-  push:
-    branches:
-    - 'main'
-    - 'v2'
-  pull_request:
-  pull_request_target:
-    types: [labeled]
   schedule:
-  - cron:  '0 2 * * *'
+    - cron:  '0 2 * * *'
 
 jobs:
   unit:
-   # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)  
-    if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
     name: unit tests
     runs-on: "ubuntu-latest"
     strategy:
@@ -38,28 +29,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: Remove PR label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                name: 'tests: run',
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number
-              });
-            } catch (e) {
-              console.log('Failed to remove label. Another job may have already removed it!');
-            }
-
       - name: Checkout code
         uses: 'actions/checkout@v3'
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: v2
 
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v3
@@ -78,8 +51,6 @@ jobs:
         run: go test -short -race -v ./...
 
   integration:
-   # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)  
-    if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
     name: integration tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -90,28 +61,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: Remove PR label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                name: 'tests: run',
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number
-              });
-            } catch (e) {
-              console.log('Failed to remove label. Another job may have already removed it!');
-            }
-
       - name: Checkout code
         uses: 'actions/checkout@v3'
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: v2
 
       - name: Setup Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
Allowing v2 branch to use Github Actions for tests.

Need new file `v2-periodic.yaml` because `schedule` event by default is only configurable on default branch (main). So need explicit new schedule action to checkout v2 branch and run tests.