### PR TITLE
feat: add max connections flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,6 +127,9 @@ any client SSL certificates.`,
 		"Path to a service account key to use for authentication.")
 	cmd.PersistentFlags().BoolVarP(&c.conf.GcloudAuth, "gcloud-auth", "g", false,
 		"Use gcloud's user configuration to retrieve a token for authentication.")
+	cmd.PersistentFlags().Uint32Var(&c.conf.MaxConnections, "max-connections", 0,
+		`Limits the number of connections by refusing any additional connections.
+When this flag is not set, there is no limit.`)
 	cmd.PersistentFlags().StringVar(&c.telemetryProject, "telemetry-project", "",
 		"Enable Cloud Monitoring and Cloud Trace integration with the provided project ID.")
 	cmd.PersistentFlags().BoolVar(&c.disableTraces, "disable-traces", false,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -191,12 +191,18 @@ func TestNewCommandArguments(t *testing.T) {
 		},
 		{
 			desc: "using the iam authn login query param",
-			// the query param's presence equates to true
 			args: []string{"proj:region:inst?auto-iam-authn=true"},
 			want: withDefaults(&proxy.Config{
 				Instances: []proxy.InstanceConnConfig{{
 					IAMAuthN: &trueValue,
 				}},
+			}),
+		},
+		{
+			desc: "using the max connections flag",
+			args: []string{"--max-connections", "1", "proj:region:inst"},
+			want: withDefaults(&proxy.Config{
+				MaxConnections: 1,
 			}),
 		},
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -16,27 +16,45 @@ package proxy_test
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/cloudsql"
+	"cloud.google.com/go/cloudsqlconn"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/proxy"
 	"github.com/spf13/cobra"
 )
 
 type fakeDialer struct {
-	cloudsql.Dialer
+	mu        sync.Mutex
+	dialCount int
 }
 
-func (fakeDialer) Close() error {
+func (*fakeDialer) Close() error {
 	return nil
 }
 
-func (fakeDialer) EngineVersion(_ context.Context, inst string) (string, error) {
+func (f *fakeDialer) dialAttempts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.dialCount
+}
+
+func (f *fakeDialer) Dial(ctx context.Context, inst string, opts ...cloudsqlconn.DialOption) (net.Conn, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dialCount++
+	c1, _ := net.Pipe()
+	return c1, nil
+}
+
+func (*fakeDialer) EngineVersion(_ context.Context, inst string) (string, error) {
 	switch {
 	case strings.Contains(inst, "pg"):
 		return "POSTGRES_14", nil
@@ -211,7 +229,7 @@ func TestClientInitialization(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			c, err := proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, tc.in)
+			c, err := proxy.NewClient(ctx, &fakeDialer{}, &cobra.Command{}, tc.in)
 			if err != nil {
 				t.Fatalf("want error = nil, got = %v", err)
 			}
@@ -241,6 +259,50 @@ func TestClientInitialization(t *testing.T) {
 	}
 }
 
+func TestClientLimitsMaxConnections(t *testing.T) {
+	in := &proxy.Config{
+		Addr: "127.0.0.1",
+		Port: 5000,
+		Instances: []proxy.InstanceConnConfig{
+			{Name: "proj:region:pg"},
+		},
+		MaxConnections: 1,
+	}
+	d := &fakeDialer{}
+	c, err := proxy.NewClient(context.Background(), d, &cobra.Command{}, in)
+	if err != nil {
+		t.Fatalf("proxy.NewClient error: %v", err)
+	}
+	defer c.Close()
+	go c.Serve(context.Background())
+
+	conn1, err1 := net.Dial("tcp", "127.0.0.1:5000")
+	if err1 != nil {
+		t.Fatalf("net.Dial error: %v", err1)
+	}
+	defer conn1.Close()
+
+	conn2, err2 := net.Dial("tcp", "127.0.0.1:5000")
+	if err2 != nil {
+		t.Fatalf("net.Dial error: %v", err1)
+	}
+	defer conn2.Close()
+
+	// try to read to check if the connection is closed
+	// wait only a second for the result (since nothing is writing to the
+	// socket)
+	conn2.SetReadDeadline(time.Now().Add(time.Second))
+	_, rErr := conn2.Read(make([]byte, 1))
+	if rErr != io.EOF {
+		t.Fatalf("conn.Read should return io.EOF, got = %v", rErr)
+	}
+
+	want := 1
+	if got := d.dialAttempts(); got != want {
+		t.Fatalf("dial attempts did not match expected, want = %v, got = %v", want, got)
+	}
+}
+
 func TestClientInitializationWorksRepeatedly(t *testing.T) {
 	// The client creates a Unix socket on initial startup and does not remove
 	// it on shutdown. This test ensures the existing socket does not cause
@@ -255,13 +317,13 @@ func TestClientInitializationWorksRepeatedly(t *testing.T) {
 			{Name: "proj:region:pg"},
 		},
 	}
-	c, err := proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, in)
+	c, err := proxy.NewClient(ctx, &fakeDialer{}, &cobra.Command{}, in)
 	if err != nil {
 		t.Fatalf("want error = nil, got = %v", err)
 	}
 	c.Close()
 
-	c, err = proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, in)
+	c, err = proxy.NewClient(ctx, &fakeDialer{}, &cobra.Command{}, in)
 	if err != nil {
 		t.Fatalf("want error = nil, got = %v", err)
 	}


### PR DESCRIPTION
The max connections flags allows callers to limit the number of outgoing
connections to the Cloud SQL backend. Max connections are tracked on a
global level across all instances.