### PR TITLE
chore: Move dialer options out of cmd/main.go and into internal/proxy.go

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -26,7 +26,6 @@ import (
 	"cloud.google.com/go/cloudsqlconn"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/proxy"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +35,9 @@ func TestNewCommandArguments(t *testing.T) {
 	trueValue := true
 
 	withDefaults := func(c *proxy.Config) *proxy.Config {
+		if c.UserAgent == "" {
+			c.UserAgent = userAgent
+		}
 		if c.Addr == "" {
 			c.Addr = "127.0.0.1"
 		}
@@ -218,8 +220,7 @@ func TestNewCommandArguments(t *testing.T) {
 				t.Fatalf("want error = nil, got = %v", err)
 			}
 
-			opts := cmpopts.IgnoreFields(proxy.Config{}, "DialerOpts")
-			if got := c.conf; !cmp.Equal(tc.want, got, opts) {
+			if got := c.conf; !cmp.Equal(tc.want, got) {
 				t.Fatalf("want = %#v\ngot = %#v\ndiff = %v", tc.want, got, cmp.Diff(tc.want, got))
 			}
 		})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -88,9 +88,9 @@ type Config struct {
 	Dialer cloudsql.Dialer
 }
 
-// MakeDialerOptions builds appropriate list of options from the Config
+// DialerOptions builds appropriate list of options from the Config
 // values for use by cloudsqlconn.NewClient()
-func (c *Config) MakeDialerOptions() ([]cloudsqlconn.Option, error) {
+func (c *Config) DialerOptions() ([]cloudsqlconn.Option, error) {
 	opts := []cloudsqlconn.Option{
 		cloudsqlconn.WithUserAgent(c.UserAgent),
 	}
@@ -178,7 +178,7 @@ func NewClient(ctx context.Context, cmd *cobra.Command, conf *Config) (*Client, 
 	d := conf.Dialer
 	if d == nil {
 		var err error
-		dialerOpts, err := conf.MakeDialerOptions()
+		dialerOpts, err := conf.DialerOptions()
 		if err != nil {
 			return nil, fmt.Errorf("error initializing dialer: %v", err)
 		}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -211,7 +211,8 @@ func TestClientInitialization(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			c, err := proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, tc.in)
+			tc.in.Dialer = fakeDialer{}
+			c, err := proxy.NewClient(ctx, &cobra.Command{}, tc.in)
 			if err != nil {
 				t.Fatalf("want error = nil, got = %v", err)
 			}
@@ -254,14 +255,16 @@ func TestClientInitializationWorksRepeatedly(t *testing.T) {
 		Instances: []proxy.InstanceConnConfig{
 			{Name: "proj:region:pg"},
 		},
+		Dialer: fakeDialer{},
 	}
-	c, err := proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, in)
+
+	c, err := proxy.NewClient(ctx, &cobra.Command{}, in)
 	if err != nil {
 		t.Fatalf("want error = nil, got = %v", err)
 	}
 	c.Close()
 
-	c, err = proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, in)
+	c, err = proxy.NewClient(ctx, &cobra.Command{}, in)
 	if err != nil {
 		t.Fatalf("want error = nil, got = %v", err)
 	}


### PR DESCRIPTION
This consolidates all code relating to cloud.google.com/go/cloudsqlconn into the internal/proxy package.