### PR TITLE
feat: add --sqladmin-api-endpoint flag for specifying sqladmin api endpoint

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,6 +138,8 @@ any client SSL certificates.`,
 		"Enable Prometheus for metric collection using the provided namespace")
 	cmd.PersistentFlags().StringVar(&c.httpPort, "http-port", "9090",
 		"Port for the Prometheus server to use")
+	cmd.PersistentFlags().StringVar(&c.conf.ApiEndpointUrl, "api-endpoint-url", "",
+		"When set, the proxy uses this url as the base API path. Example: https://sqladmin.googleapis.com")
 
 	// Global and per instance flags
 	cmd.PersistentFlags().StringVarP(&c.conf.Addr, "address", "a", "127.0.0.1",
@@ -197,6 +199,18 @@ func parseConfig(cmd *cobra.Command, conf *proxy.Config, args []string) error {
 	}
 	if !userHasSet("telemetry-project") && userHasSet("disable-traces") {
 		cmd.Println("Ignoring disable-traces as telemetry-project was not set")
+	}
+
+	if userHasSet("api-endpoint-url") && conf.ApiEndpointUrl != "" {
+		_, err := url.Parse(conf.ApiEndpointUrl)
+		if err != nil {
+			return newBadCommandError(fmt.Sprintf("the value provided for --api-endpoint is not a valid url, %v", conf.ApiEndpointUrl))
+		}
+
+		// add a trailing '/' if omitted
+		if !strings.HasSuffix(conf.ApiEndpointUrl, "/") {
+			conf.ApiEndpointUrl = conf.ApiEndpointUrl + "/"
+		}
 	}
 
 	var ics []proxy.InstanceConnConfig

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,7 @@ any client SSL certificates.`,
 		"Enable Prometheus for metric collection using the provided namespace")
 	cmd.PersistentFlags().StringVar(&c.httpPort, "http-port", "9090",
 		"Port for the Prometheus server to use")
-	cmd.PersistentFlags().StringVar(&c.conf.ApiEndpointUrl, "api-endpoint-url", "",
+	cmd.PersistentFlags().StringVar(&c.conf.ApiEndpointUrl, "sqladmin-api-endpoint", "",
 		"When set, the proxy uses this url as the base API path. Example: https://sqladmin.googleapis.com")
 
 	// Global and per instance flags
@@ -201,7 +201,7 @@ func parseConfig(cmd *cobra.Command, conf *proxy.Config, args []string) error {
 		cmd.Println("Ignoring disable-traces as telemetry-project was not set")
 	}
 
-	if userHasSet("api-endpoint-url") && conf.ApiEndpointUrl != "" {
+	if userHasSet("sqladmin-api-endpoint") && conf.ApiEndpointUrl != "" {
 		_, err := url.Parse(conf.ApiEndpointUrl)
 		if err != nil {
 			return newBadCommandError(fmt.Sprintf("the value provided for --api-endpoint is not a valid url, %v", conf.ApiEndpointUrl))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -156,14 +156,14 @@ func TestNewCommandArguments(t *testing.T) {
 		},
 		{
 			desc: "using the api-endpoint flag without trailing slash",
-			args: []string{"--api-endpoint-url", "https://test.googleapis.com", "proj:region:inst"},
+			args: []string{"--sqladmin-api-endpoint", "https://test.googleapis.com", "proj:region:inst"},
 			want: withDefaults(&proxy.Config{
 				ApiEndpointUrl: "https://test.googleapis.com/",
 			}),
 		},
 		{
 			desc: "using the api-endpoint flag with trailing slash",
-			args: []string{"--api-endpoint-url", "https://test.googleapis.com/", "proj:region:inst"},
+			args: []string{"--sqladmin-api-endpoint", "https://test.googleapis.com/", "proj:region:inst"},
 			want: withDefaults(&proxy.Config{
 				ApiEndpointUrl: "https://test.googleapis.com/",
 			}),
@@ -393,8 +393,8 @@ func TestNewCommandWithErrors(t *testing.T) {
 			args: []string{"--htto-port", "1111", "proj:region:inst"},
 		},
 		{
-			desc: "using an invalid url for api-endpoint-url",
-			args: []string{"--api-endpoint-url", "https://user:abc{DEf1=ghi@example.com:5432/db?sslmode=require", "proj:region:inst"},
+			desc: "using an invalid url for sqladmin-api-endpoint",
+			args: []string{"--sqladmin-api-endpoint", "https://user:abc{DEf1=ghi@example.com:5432/db?sslmode=require", "proj:region:inst"},
 		},
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -155,6 +155,20 @@ func TestNewCommandArguments(t *testing.T) {
 			}),
 		},
 		{
+			desc: "using the api-endpoint flag without trailing slash",
+			args: []string{"--api-endpoint-url", "https://test.googleapis.com", "proj:region:inst"},
+			want: withDefaults(&proxy.Config{
+				ApiEndpointUrl: "https://test.googleapis.com/",
+			}),
+		},
+		{
+			desc: "using the api-endpoint flag with trailing slash",
+			args: []string{"--api-endpoint-url", "https://test.googleapis.com/", "proj:region:inst"},
+			want: withDefaults(&proxy.Config{
+				ApiEndpointUrl: "https://test.googleapis.com/",
+			}),
+		},
+		{
 			desc: "using the unix socket flag",
 			args: []string{"--unix-socket", "/path/to/dir/", "proj:region:inst"},
 			want: withDefaults(&proxy.Config{
@@ -377,6 +391,10 @@ func TestNewCommandWithErrors(t *testing.T) {
 		{
 			desc: "enabling a Prometheus port without a namespace",
 			args: []string{"--htto-port", "1111", "proj:region:inst"},
+		},
+		{
+			desc: "using an invalid url for api-endpoint-url",
+			args: []string{"--api-endpoint-url", "https://user:abc{DEf1=ghi@example.com:5432/db?sslmode=require", "proj:region:inst"},
 		},
 	}
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -71,6 +71,10 @@ type Config struct {
 	// increments from this value.
 	Port int
 
+	// ApiEndpointUrl is the URL of the google cloud sql api. When left blank,
+	// the proxy will use the main public api: https://sqladmin.googleapis.com/
+	ApiEndpointUrl string
+
 	// UnixSocket is the directory where Unix sockets will be created,
 	// connected to any Instances. If set, takes precedence over Addr and Port.
 	UnixSocket string
@@ -110,6 +114,10 @@ func (c *Config) DialerOptions() ([]cloudsqlconn.Option, error) {
 		}
 		opts = append(opts, cloudsqlconn.WithTokenSource(ts))
 	default:
+	}
+
+	if c.ApiEndpointUrl != "" {
+		opts = append(opts, cloudsqlconn.WithAdminAPIEndpoint(c.ApiEndpointUrl))
 	}
 
 	if c.IAMAuthN {


### PR DESCRIPTION
Specifies an alternate api endpoint to use for calling the cloud sql admin 
api instead of https://sqladmin.googleapis.com/. This replaces the
This new flag replaces the -host flag in cloudsql-proxy V1. 
