### PR TITLE
feat: add max-sigterm-delay flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,10 +127,12 @@ any client SSL certificates.`,
 	cmd.PersistentFlags().Uint64Var(&c.conf.MaxConnections, "max-connections", 0,
 		`Limits the number of connections by refusing any additional connections.
 When this flag is not set, there is no limit.`)
-	cmd.PersistentFlags().DurationVar(&c.conf.WaitOnClose, "wait-after-sigterm", 0,
-		`Amount of time to wait for any open connections to close before
-shutting down the proxy. When this flag is not set, the proxy
-will shutdown immediately after receiving a SIGTERM.`)
+	cmd.PersistentFlags().DurationVar(&c.conf.WaitOnClose, "max-sigterm-delay", 0,
+		`Maximum amount of time to wait after for any open connections
+to close after receiving a TERM signal. The proxy will shut
+down when the number of open connections reaches 0 or when
+the maximum time has passed. Defaults to 0s.`)
+
 	cmd.PersistentFlags().StringVar(&c.telemetryProject, "telemetry-project", "",
 		"Enable Cloud Monitoring and Cloud Trace integration with the provided project ID.")
 	cmd.PersistentFlags().BoolVar(&c.disableTraces, "disable-traces", false,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,6 +127,9 @@ any client SSL certificates.`,
 		"Path to a service account key to use for authentication.")
 	cmd.PersistentFlags().BoolVarP(&c.conf.GcloudAuth, "gcloud-auth", "g", false,
 		"Use gcloud's user configuration to retrieve a token for authentication.")
+	cmd.PersistentFlags().Uint32Var(&c.conf.MaxConnections, "max-connections", 0,
+		`Limits the number of connections by refusing any additional connections.
+When this flag is not set, there is no limit.`)
 	cmd.PersistentFlags().StringVar(&c.telemetryProject, "telemetry-project", "",
 		"Enable Cloud Monitoring and Cloud Trace integration with the provided project ID.")
 	cmd.PersistentFlags().BoolVar(&c.disableTraces, "disable-traces", false,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -223,7 +223,7 @@ func TestNewCommandArguments(t *testing.T) {
 		},
 		{
 			desc: "using wait after signterm flag",
-			args: []string{"--wait-after-sigterm", "10s", "proj:region:inst"},
+			args: []string{"--max-sigterm-delay", "10s", "proj:region:inst"},
 			want: withDefaults(&proxy.Config{
 				WaitOnClose: 10 * time.Second,
 			}),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -191,12 +191,18 @@ func TestNewCommandArguments(t *testing.T) {
 		},
 		{
 			desc: "using the iam authn login query param",
-			// the query param's presence equates to true
 			args: []string{"proj:region:inst?auto-iam-authn=true"},
 			want: withDefaults(&proxy.Config{
 				Instances: []proxy.InstanceConnConfig{{
 					IAMAuthN: &trueValue,
 				}},
+			}),
+		},
+		{
+			desc: "using the max connections flag",
+			args: []string{"--max-connections", "1", "proj:region:inst"},
+			want: withDefaults(&proxy.Config{
+				MaxConnections: 1,
 			}),
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -205,6 +205,13 @@ func TestNewCommandArguments(t *testing.T) {
 				MaxConnections: 1,
 			}),
 		},
+		{
+			desc: "using wait after signterm flag",
+			args: []string{"--wait-after-sigterm", "10s", "proj:region:inst"},
+			want: withDefaults(&proxy.Config{
+				WaitOnClose: 10 * time.Second,
+			}),
+		},
 	}
 
 	for _, tc := range tcs {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -361,8 +361,6 @@ func (c *Client) Close() error {
 	open := atomic.LoadUint32(&c.connCount)
 	if open > 0 {
 		mErr = append(mErr, fmt.Errorf("%d connection(s) still open after waiting %v", open, c.waitOnClose))
-	}
-	if len(mErr) > 0 {
 		return mErr
 	}
 	return nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -418,7 +418,6 @@ func (c *Client) serveSocketMount(ctx context.Context, s *socketMount) error {
 type socketMount struct {
 	inst     string
 	dialOpts []cloudsqlconn.DialOption
-	mu       sync.Mutex
 	listener net.Listener
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -361,6 +361,8 @@ func (c *Client) Close() error {
 	open := atomic.LoadUint32(&c.connCount)
 	if open > 0 {
 		mErr = append(mErr, fmt.Errorf("%d connection(s) still open after waiting %v", open, c.waitOnClose))
+	}
+	if len(mErr) > 0 {
 		return mErr
 	}
 	return nil

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -363,8 +363,16 @@ func TestClientCloseWaitsForActiveConnections(t *testing.T) {
 	}
 	go c.Serve(context.Background())
 
-	conn = tryTCPDial(t, "127.0.0.1:5001")
-	defer conn.Close() // close the connection only after trying to close the proxy
+	var open []net.Conn
+	for i := 0; i < 5; i++ {
+		conn = tryTCPDial(t, "127.0.0.1:5001")
+		open = append(open, conn)
+	}
+	defer func() {
+		for _, o := range open {
+			o.Close()
+		}
+	}()
 
 	if err := c.Close(); err == nil {
 		t.Fatal("c.Close should error, got = nil")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -72,7 +72,7 @@ type errorDialer struct {
 	fakeDialer
 }
 
-func (errorDialer) Close() error {
+func (*errorDialer) Close() error {
 	return errors.New("errorDialer returns error on Close")
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -355,14 +355,15 @@ func TestClientCloseWaitsForActiveConnections(t *testing.T) {
 		t.Fatalf("c.Close error: %v", err)
 	}
 
-	in.WaitOnClose = 500 * time.Millisecond
+	in.WaitOnClose = time.Second
+	in.Port = 5001
 	c, err = proxy.NewClient(context.Background(), &cobra.Command{}, in)
 	if err != nil {
 		t.Fatalf("proxy.NewClient error: %v", err)
 	}
 	go c.Serve(context.Background())
 
-	_ = tryTCPDial(t, "127.0.0.1:5000")
+	conn = tryTCPDial(t, "127.0.0.1:5001")
 	defer conn.Close() // close the connection only after trying to close the proxy
 
 	if err := c.Close(); err == nil {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -16,27 +16,45 @@ package proxy_test
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/cloudsql"
+	"cloud.google.com/go/cloudsqlconn"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/proxy"
 	"github.com/spf13/cobra"
 )
 
 type fakeDialer struct {
-	cloudsql.Dialer
+	mu        sync.Mutex
+	dialCount int
 }
 
-func (fakeDialer) Close() error {
+func (*fakeDialer) Close() error {
 	return nil
 }
 
-func (fakeDialer) EngineVersion(_ context.Context, inst string) (string, error) {
+func (f *fakeDialer) dialAttempts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.dialCount
+}
+
+func (f *fakeDialer) Dial(ctx context.Context, inst string, opts ...cloudsqlconn.DialOption) (net.Conn, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dialCount++
+	c1, _ := net.Pipe()
+	return c1, nil
+}
+
+func (*fakeDialer) EngineVersion(_ context.Context, inst string) (string, error) {
 	switch {
 	case strings.Contains(inst, "pg"):
 		return "POSTGRES_14", nil
@@ -211,7 +229,7 @@ func TestClientInitialization(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			c, err := proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, tc.in)
+			c, err := proxy.NewClient(ctx, &fakeDialer{}, &cobra.Command{}, tc.in)
 			if err != nil {
 				t.Fatalf("want error = nil, got = %v", err)
 			}
@@ -241,6 +259,50 @@ func TestClientInitialization(t *testing.T) {
 	}
 }
 
+func TestClientLimitsMaxConnections(t *testing.T) {
+	in := &proxy.Config{
+		Addr: "127.0.0.1",
+		Port: 5000,
+		Instances: []proxy.InstanceConnConfig{
+			{Name: "proj:region:pg"},
+		},
+		MaxConnections: 1,
+	}
+	d := &fakeDialer{}
+	c, err := proxy.NewClient(context.Background(), d, &cobra.Command{}, in)
+	if err != nil {
+		t.Fatalf("proxy.NewClient error: %v", err)
+	}
+	defer c.Close()
+	go c.Serve(context.Background())
+
+	conn1, err1 := net.Dial("tcp", "127.0.0.1:5000")
+	if err1 != nil {
+		t.Fatalf("net.Dial error: %v", err1)
+	}
+	defer conn1.Close()
+
+	conn2, err2 := net.Dial("tcp", "127.0.0.1:5000")
+	if err2 != nil {
+		t.Fatalf("net.Dial error: %v", err1)
+	}
+	defer conn2.Close()
+
+	// try to read to check if the connection is closed
+	// wait only a second for the result (since nothing is writing to the
+	// socket)
+	conn2.SetReadDeadline(time.Now().Add(time.Second))
+	_, rErr := conn2.Read(make([]byte, 1))
+	if rErr != io.EOF {
+		t.Fatalf("conn.Read should return io.EOF, got = %v", rErr)
+	}
+
+	want := 1
+	if got := d.dialAttempts(); got != want {
+		t.Fatalf("dial attempts did not match expected, want = %v, got = %v", want, got)
+	}
+}
+
 func TestClientInitializationWorksRepeatedly(t *testing.T) {
 	// The client creates a Unix socket on initial startup and does not remove
 	// it on shutdown. This test ensures the existing socket does not cause
@@ -255,13 +317,13 @@ func TestClientInitializationWorksRepeatedly(t *testing.T) {
 			{Name: "proj:region:pg"},
 		},
 	}
-	c, err := proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, in)
+	c, err := proxy.NewClient(ctx, &fakeDialer{}, &cobra.Command{}, in)
 	if err != nil {
 		t.Fatalf("want error = nil, got = %v", err)
 	}
 	c.Close()
 
-	c, err = proxy.NewClient(ctx, fakeDialer{}, &cobra.Command{}, in)
+	c, err = proxy.NewClient(ctx, &fakeDialer{}, &cobra.Command{}, in)
 	if err != nil {
 		t.Fatalf("want error = nil, got = %v", err)
 	}


### PR DESCRIPTION
This is the v2 version of term_timeout and will make proxy wait at most
for the specified duration beforing existing once a SIGTERM has been
received by the process.