### PR TITLE
chore: extract ProxyServer interface

### DIFF
--- a/internal/connection/alignment_test.go
+++ b/internal/connection/alignment_test.go
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy
+package connection
 
 import (
 	"testing"
 	"unsafe"
 )
 
-func TestClientUsesSyncAtomicAlignment(t *testing.T) {
+func TestCounterUsesSyncAtomicAlignment(t *testing.T) {
 	// The sync/atomic pkg has a bug that requires the developer to guarantee
 	// 64-bit alignment when using 64-bit functions on 32-bit systems.
-	c := &Client{}
+	c := NewCounter(0)
 
-	if a := unsafe.Offsetof(c.connCount); a%64 != 0 {
-		t.Errorf("Client.connCount is not 64-bit aligned: want 0, got %v", a)
+	if a := unsafe.Offsetof(c.count); a%64 != 0 {
+		t.Errorf("Counter.count is not 64-bit aligned: want 0, got %v", a)
 	}
 }

--- a/internal/connection/connection.go
+++ b/internal/connection/connection.go
@@ -182,24 +182,3 @@ func (c *Counter) Inc() (func(), error) {
 	}
 	return cleanup, nil
 }
-c *Counter) IsZero() bool {
-	return atomic.LoadUint64(&c.count) == 0
-}
-
-// Count reports the number of open connections, and the maximum configured
-// connections.
-func (c *Counter) Count() (uint64, uint64) {
-	return atomic.LoadUint64(&c.count), c.max
-}
-
-// Inc increases the count. Callers should cal the cleanup function to decrement
-// the count.
-func (c *Counter) Inc() (func(), error) {
-	count := atomic.AddUint64(&c.count, 1)
-	cleanup := func() { atomic.AddUint64(&c.count, ^uint64(0)) }
-
-	if c.max > 0 && count > c.max {
-		return func() {}, errMaxExceeded
-	}
-	return cleanup, nil
-}

--- a/internal/connection/connection.go
+++ b/internal/connection/connection.go
@@ -1,0 +1,166 @@
+package connection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cloud.google.com/go/cloudsqlconn"
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/cloudsql"
+)
+
+// serveSocketMount persistently listens to the socketMounts listener and proxies connections to a
+// given Cloud SQL instance.
+func AcceptAndHandle(ctx context.Context, ln net.Listener, l cloudsql.Logger, d cloudsql.Dialer, counter *Counter, instance string, opts ...cloudsqlconn.DialOption) error {
+	for {
+		cConn, err := ln.Accept()
+		if err != nil {
+			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+				l.Errorf("[%s] Error accepting connection: %v", instance, err)
+				// For transient errors, wait a small amount of time to see if it resolves itself
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+		// handle the connection in a separate goroutine
+		go func() {
+			l.Infof("[%s] accepted connection from %s", instance, cConn.RemoteAddr())
+
+			// A client has established a connection to the local socket. Before
+			// we initiate a connection to the Cloud SQL backend, increment the
+			// connection counter. If the total number of connections exceeds
+			// the maximum, refuse to connect and close the client connection.
+			dec, err := counter.Inc()
+			if err != nil {
+				_, max := counter.Count()
+				l.Infof("max connections (%v) exceeded, refusing new connection", max)
+				_ = cConn.Close()
+				return
+			}
+			defer dec()
+
+			// give a max of 30 seconds to connect to the instance
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			sConn, err := d.Dial(ctx, instance, opts...)
+			if err != nil {
+				l.Errorf("[%s] failed to connect to instance: %v", instance, err)
+				cConn.Close()
+				return
+			}
+			Copy(l, instance, cConn, sConn)
+		}()
+	}
+}
+
+// Copy sets up a bidirectional copy between two open connections
+func Copy(l cloudsql.Logger, inst string, client, server net.Conn) {
+	// only allow the first side to give an error for terminating a connection
+	var o sync.Once
+	cleanup := func(errDesc string, isErr bool) {
+		o.Do(func() {
+			client.Close()
+			server.Close()
+			if isErr {
+				l.Errorf(errDesc)
+			} else {
+				l.Infof(errDesc)
+			}
+		})
+	}
+
+	// copy bytes from client to server
+	go func() {
+		buf := make([]byte, 8*1024) // 8kb
+		for {
+			n, cErr := client.Read(buf)
+			var sErr error
+			if n > 0 {
+				_, sErr = server.Write(buf[:n])
+			}
+			switch {
+			case cErr == io.EOF:
+				cleanup(fmt.Sprintf("[%s] client closed the connection", inst), false)
+				return
+			case cErr != nil:
+				cleanup(fmt.Sprintf("[%s] connection aborted - error reading from client: %v", inst, cErr), true)
+				return
+			case sErr == io.EOF:
+				cleanup(fmt.Sprintf("[%s] instance closed the connection", inst), false)
+				return
+			case sErr != nil:
+				cleanup(fmt.Sprintf("[%s] connection aborted - error writing to instance: %v", inst, cErr), true)
+				return
+			}
+		}
+	}()
+
+	// copy bytes from server to client
+	buf := make([]byte, 8*1024) // 8kb
+	for {
+		n, sErr := server.Read(buf)
+		var cErr error
+		if n > 0 {
+			_, cErr = client.Write(buf[:n])
+		}
+		switch {
+		case sErr == io.EOF:
+			cleanup(fmt.Sprintf("[%s] instance closed the connection", inst), false)
+			return
+		case sErr != nil:
+			cleanup(fmt.Sprintf("[%s] connection aborted - error reading from instance: %v", inst, sErr), true)
+			return
+		case cErr == io.EOF:
+			cleanup(fmt.Sprintf("[%s] client closed the connection", inst), false)
+			return
+		case cErr != nil:
+			cleanup(fmt.Sprintf("[%s] connection aborted - error writing to client: %v", inst, sErr), true)
+			return
+		}
+	}
+}
+
+var errMaxExceeded = errors.New("max connections exceeded")
+
+// NewCounter initializes a Counter.
+func NewCounter(max uint64) *Counter {
+	return &Counter{max: max}
+}
+
+// Counter tracks a count next to a maximum value.
+type Counter struct {
+	// count tracks the number of all open connections from the Client to
+	// all Cloud SQL instances.
+	count uint64
+
+	// maxConns is the maximum number of allowed connections tracked by
+	// connCount. If not set, there is no limit.
+	max uint64
+}
+
+func (c *Counter) IsZero() bool {
+	return atomic.LoadUint64(&c.count) == 0
+}
+
+func (c *Counter) Count() (uint64, uint64) {
+	return c.count, c.max
+}
+
+// Inc increases the count. Callers should cal the cleanup function to decrement
+// the count.
+func (c *Counter) Inc() (func(), error) {
+	count := atomic.AddUint64(&c.count, 1)
+	cleanup := func() { atomic.AddUint64(&c.count, ^uint64(0)) }
+
+	if c.max > 0 && count > c.max {
+		return func() {}, errMaxExceeded
+	}
+	return cleanup, nil
+}

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -31,12 +31,12 @@ import (
 type Check struct {
 	once    *sync.Once
 	started chan struct{}
-	proxy   *proxy.Client
+	proxy   *proxy.Session
 	logger  cloudsql.Logger
 }
 
 // NewCheck is the initializer for Check.
-func NewCheck(p *proxy.Client, l cloudsql.Logger) *Check {
+func NewCheck(p *proxy.Session, l cloudsql.Logger) *Check {
 	return &Check{
 		once:    &sync.Once{},
 		started: make(chan struct{}),

--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -79,7 +79,7 @@ func (*errorDialer) Dial(ctx context.Context, inst string, opts ...cloudsqlconn.
 	return nil, errors.New("errorDialer always errors")
 }
 
-func newProxyWithParams(t *testing.T, maxConns uint64, dialer cloudsql.Dialer) *proxy.Client {
+func newProxyWithParams(t *testing.T, maxConns uint64, dialer cloudsql.Dialer) *proxy.Session {
 	c := &proxy.Config{
 		Addr: proxyHost,
 		Port: proxyPort,
@@ -88,22 +88,22 @@ func newProxyWithParams(t *testing.T, maxConns uint64, dialer cloudsql.Dialer) *
 		},
 		MaxConnections: maxConns,
 	}
-	p, err := proxy.NewClient(context.Background(), dialer, logger, c)
+	p, err := proxy.NewSession(context.Background(), dialer, logger, c)
 	if err != nil {
 		t.Fatalf("proxy.NewClient: %v", err)
 	}
 	return p
 }
 
-func newTestProxyWithMaxConns(t *testing.T, maxConns uint64) *proxy.Client {
+func newTestProxyWithMaxConns(t *testing.T, maxConns uint64) *proxy.Session {
 	return newProxyWithParams(t, maxConns, &fakeDialer{})
 }
 
-func newTestProxyWithDialer(t *testing.T, d cloudsql.Dialer) *proxy.Client {
+func newTestProxyWithDialer(t *testing.T, d cloudsql.Dialer) *proxy.Session {
 	return newProxyWithParams(t, 0, d)
 }
 
-func newTestProxy(t *testing.T) *proxy.Client {
+func newTestProxy(t *testing.T) *proxy.Session {
 	return newProxyWithParams(t, 0, &fakeDialer{})
 }
 
@@ -174,7 +174,7 @@ func TestHandleReadinessForMaxConns(t *testing.T) {
 	}()
 	started := make(chan struct{})
 	check := healthcheck.NewCheck(p, logger)
-	go p.Serve(context.Background(), func() {
+	go p.Start(context.Background(), func() {
 		check.NotifyStarted()
 		close(started)
 	})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/cloudsql"
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/connection"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/gcloud"
 	"golang.org/x/oauth2"
 )
@@ -222,21 +222,147 @@ func (c *portConfig) nextDBPort(version string) int {
 	}
 }
 
-// Client proxies connections from a local client to the remote server side
-// proxy for multiple Cloud SQL instances.
-type Client struct {
-	// connCount tracks the number of all open connections from the Client to
-	// all Cloud SQL instances.
-	connCount uint64
+// socketProxy is a server that uses TCP or Unix domain sockets to proxy traffic
+// to and from a Cloud SQL insteand and the corresponding socket.
+type socketProxy struct {
+	sockets []*socket
+	conf    *Config
+	dialer  cloudsql.Dialer
+	logger  cloudsql.Logger
+	counter *connection.Counter
+}
 
-	// maxConns is the maximum number of allowed connections tracked by
-	// connCount. If not set, there is no limit.
-	maxConns uint64
+// newSocketProxy creates a socketProxy.
+func newSocketProxy(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, c *connection.Counter, conf *Config) (*socketProxy, error) {
+	var mnts []*socket
+	pc := newPortConfig(conf.Port)
+	for _, inst := range conf.Instances {
+		version, err := d.EngineVersion(ctx, inst.Name)
+		if err != nil {
+			return nil, err
+		}
 
+		m, err := newSocket(ctx, conf, pc, inst, version)
+		if err != nil {
+			for _, m := range mnts {
+				mErr := m.listener.Close()
+				if mErr != nil {
+					l.Errorf("failed to close mount: %v", mErr)
+				}
+			}
+			return nil, fmt.Errorf("[%v] Unable to mount socket: %v", inst.Name, err)
+		}
+
+		l.Infof("[%s] Listening on %s", inst.Name, m.listener.Addr())
+		mnts = append(mnts, m)
+	}
+	return &socketProxy{
+		sockets: mnts,
+		conf:    conf,
+		dialer:  d,
+		logger:  l,
+		counter: c,
+	}, nil
+}
+
+func (s *socketProxy) Serve(ctx context.Context, exitCh chan<- error) {
+	for _, m := range s.sockets {
+		go func(mnt *socket) {
+			err := connection.AcceptAndHandle(ctx, mnt.listener, s.logger, s.dialer, s.counter, mnt.inst, mnt.dialOpts...)
+			if err != nil {
+				select {
+				// Best effort attempt to send error.
+				// If this send fails, it means the reading goroutine has
+				// already pulled a value out of the channel and is no longer
+				// reading any more values. In other words, we report only the
+				// first error.
+				case exitCh <- err:
+				default:
+					return
+				}
+			}
+		}(m)
+	}
+}
+
+// CheckConnections verifies that each socket can reach its backing Cloud SQL
+// instance.
+func (s *socketProxy) CheckConnections(ctx context.Context) error {
+	var (
+		wg    sync.WaitGroup
+		errCh = make(chan error, len(s.sockets))
+	)
+	for _, m := range s.sockets {
+		wg.Add(1)
+		go func(inst string) {
+			defer wg.Done()
+			conn, err := s.dialer.Dial(ctx, inst)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			cErr := conn.Close()
+			if err != nil {
+				errCh <- fmt.Errorf("%v: %v", inst, cErr)
+			}
+		}(m.inst)
+	}
+	wg.Wait()
+
+	var mErr MultiErr
+	for i := 0; i < len(s.sockets); i++ {
+		select {
+		case err := <-errCh:
+			mErr = append(mErr, err)
+		default:
+			continue
+		}
+	}
+	if len(mErr) > 0 {
+		return mErr
+	}
+	return nil
+}
+
+// Close closes all open listeners and stops the dialer from refreshing any
+// further.
+func (s *socketProxy) Close() error {
+	var mErr MultiErr
+	// First, close all open socket listeners to prevent additional connections.
+	for _, m := range s.sockets {
+		err := m.listener.Close()
+		if err != nil {
+			// TODO
+			mErr = append(mErr, err)
+		}
+	}
+	// Next, close the dialer to prevent any additional refreshes.
+	cErr := s.dialer.Close()
+	if cErr != nil {
+		mErr = append(mErr, cErr)
+	}
+	if len(mErr) > 0 {
+		return mErr
+	}
+	return nil
+}
+
+// ProxyServer serves local listeners that proxy traffic to remote Cloud SQL
+// instances.
+type ProxyServer interface {
+	Serve(ctx context.Context, exitCh chan<- error)
+	CheckConnections(context.Context) error
+	io.Closer
+}
+
+// Session represents a single invocation of the Cloud SQL Auth proxy and
+// orchestrates local listeners connected to remote Cloud SQL instances.
+type Session struct {
+	ps     ProxyServer
 	dialer cloudsql.Dialer
 
-	// mnts is a list of all mounted sockets for this client
-	mnts []*socketMount
+	// counter tracks the number of open connections
+	counter *connection.Counter
 
 	// waitOnClose is the maximum duration to wait for open connections to close
 	// when shutting down.
@@ -245,8 +371,9 @@ type Client struct {
 	logger cloudsql.Logger
 }
 
-// NewClient completes the initial setup required to get the proxy to a "steady" state.
-func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *Config) (*Client, error) {
+// NewSession completes the initial setup for a Session based on the provided
+// configuration.
+func NewSession(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *Config) (*Session, error) {
 	// Check if the caller has configured a dialer.
 	// Otherwise, initialize a new one.
 	if d == nil {
@@ -265,33 +392,21 @@ func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *
 		go func(name string) { d.EngineVersion(ctx, name) }(inst.Name)
 	}
 
-	var mnts []*socketMount
-	pc := newPortConfig(conf.Port)
-	for _, inst := range conf.Instances {
-		version, err := d.EngineVersion(ctx, inst.Name)
-		if err != nil {
-			return nil, err
-		}
-
-		m, err := newSocketMount(ctx, conf, pc, inst, version)
-		if err != nil {
-			for _, m := range mnts {
-				mErr := m.Close()
-				if mErr != nil {
-					l.Errorf("failed to close mount: %v", mErr)
-				}
-			}
-			return nil, fmt.Errorf("[%v] Unable to mount socket: %v", inst.Name, err)
-		}
-
-		l.Infof("[%s] Listening on %s", inst.Name, m.Addr())
-		mnts = append(mnts, m)
+	counter := connection.NewCounter(conf.MaxConnections)
+	var (
+		ps  ProxyServer
+		err error
+	)
+	ps, err = newSocketProxy(ctx, d, l, counter, conf)
+	if err != nil {
+		return nil, err
 	}
-	c := &Client{
-		mnts:        mnts,
+
+	c := &Session{
+		ps:          ps,
 		logger:      l,
 		dialer:      d,
-		maxConns:    conf.MaxConnections,
+		counter:     counter,
 		waitOnClose: conf.WaitOnClose,
 	}
 	return c, nil
@@ -299,72 +414,23 @@ func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *
 
 // CheckConnections dials each registered instance and reports any errors that
 // may have occurred.
-func (c *Client) CheckConnections(ctx context.Context) error {
-	var (
-		wg    sync.WaitGroup
-		errCh = make(chan error, len(c.mnts))
-	)
-	for _, m := range c.mnts {
-		wg.Add(1)
-		go func(inst string) {
-			defer wg.Done()
-			conn, err := c.dialer.Dial(ctx, inst)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			cErr := conn.Close()
-			if err != nil {
-				errCh <- fmt.Errorf("%v: %v", inst, cErr)
-			}
-		}(m.inst)
-	}
-	wg.Wait()
-
-	var mErr MultiErr
-	for i := 0; i < len(c.mnts); i++ {
-		select {
-		case err := <-errCh:
-			mErr = append(mErr, err)
-		default:
-			continue
-		}
-	}
-	if len(mErr) > 0 {
-		return mErr
-	}
-	return nil
+func (s *Session) CheckConnections(ctx context.Context) error {
+	return s.ps.CheckConnections(ctx)
 }
 
 // ConnCount returns the number of open connections and the maximum allowed
 // connections. Returns 0 when the maximum allowed connections have not been set.
-func (c *Client) ConnCount() (uint64, uint64) {
-	return atomic.LoadUint64(&c.connCount), c.maxConns
+func (s *Session) ConnCount() (uint64, uint64) {
+	return s.counter.Count()
 }
 
-// Serve starts proxying connections for all configured instances using the
+// Start starts proxying connections for all configured instances using the
 // associated socket.
-func (c *Client) Serve(ctx context.Context, notify func()) error {
+func (s *Session) Start(ctx context.Context, notify func()) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	exitCh := make(chan error)
-	for _, m := range c.mnts {
-		go func(mnt *socketMount) {
-			err := c.serveSocketMount(ctx, mnt)
-			if err != nil {
-				select {
-				// Best effort attempt to send error.
-				// If this send fails, it means the reading goroutine has
-				// already pulled a value out of the channel and is no longer
-				// reading any more values. In other words, we report only the
-				// first error.
-				case exitCh <- err:
-				default:
-					return
-				}
-			}
-		}(m)
-	}
+	s.ps.Serve(ctx, exitCh)
 	notify()
 	return <-exitCh
 }
@@ -385,42 +451,42 @@ func (m MultiErr) Error() string {
 	return strings.Join(errs, ", ")
 }
 
-// Close triggers the proxyClient to shutdown.
-func (c *Client) Close() error {
-	var mErr MultiErr
-	// First, close all open socket listeners to prevent additional connections.
-	for _, m := range c.mnts {
-		err := m.Close()
-		if err != nil {
+// Close concludes the session by closing the proxy server. If waitOnClose is
+// configured, Close waits up to waitOnClose duration for connections to close
+// and then shuts down.
+func (s *Session) Close() error {
+	var (
+		mErr MultiErr
+		ok   bool
+	)
+	if err := s.ps.Close(); err != nil {
+		mErr, ok = err.(MultiErr)
+		// If it's not a MultiErr, just append it.
+		if !ok {
 			mErr = append(mErr, err)
 		}
 	}
-	// Next, close the dialer to prevent any additional refreshes.
-	cErr := c.dialer.Close()
-	if cErr != nil {
-		mErr = append(mErr, cErr)
-	}
-	if c.waitOnClose == 0 {
+	if s.waitOnClose == 0 {
 		if len(mErr) > 0 {
 			return mErr
 		}
 		return nil
 	}
-	timeout := time.After(c.waitOnClose)
+	timeout := time.After(s.waitOnClose)
 	tick := time.Tick(100 * time.Millisecond)
 	for {
 		select {
 		case <-tick:
-			if atomic.LoadUint64(&c.connCount) > 0 {
+			if !s.counter.IsZero() {
 				continue
 			}
 		case <-timeout:
 		}
 		break
 	}
-	open := atomic.LoadUint64(&c.connCount)
+	open, _ := s.counter.Count()
 	if open > 0 {
-		mErr = append(mErr, fmt.Errorf("%d connection(s) still open after waiting %v", open, c.waitOnClose))
+		mErr = append(mErr, fmt.Errorf("%d connection(s) still open after waiting %v", open, s.waitOnClose))
 	}
 	if len(mErr) > 0 {
 		return mErr
@@ -428,60 +494,17 @@ func (c *Client) Close() error {
 	return nil
 }
 
-// serveSocketMount persistently listens to the socketMounts listener and proxies connections to a
-// given Cloud SQL instance.
-func (c *Client) serveSocketMount(ctx context.Context, s *socketMount) error {
-	for {
-		cConn, err := s.Accept()
-		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-				c.logger.Errorf("[%s] Error accepting connection: %v", s.inst, err)
-				// For transient errors, wait a small amount of time to see if it resolves itself
-				time.Sleep(10 * time.Millisecond)
-				continue
-			}
-			return err
-		}
-		// handle the connection in a separate goroutine
-		go func() {
-			c.logger.Infof("[%s] accepted connection from %s", s.inst, cConn.RemoteAddr())
-
-			// A client has established a connection to the local socket. Before
-			// we initiate a connection to the Cloud SQL backend, increment the
-			// connection counter. If the total number of connections exceeds
-			// the maximum, refuse to connect and close the client connection.
-			count := atomic.AddUint64(&c.connCount, 1)
-			defer atomic.AddUint64(&c.connCount, ^uint64(0))
-
-			if c.maxConns > 0 && count > c.maxConns {
-				c.logger.Infof("max connections (%v) exceeded, refusing new connection", c.maxConns)
-				_ = cConn.Close()
-				return
-			}
-
-			// give a max of 30 seconds to connect to the instance
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			sConn, err := c.dialer.Dial(ctx, s.inst, s.dialOpts...)
-			if err != nil {
-				c.logger.Errorf("[%s] failed to connect to instance: %v", s.inst, err)
-				cConn.Close()
-				return
-			}
-			c.proxyConn(s.inst, cConn, sConn)
-		}()
-	}
-}
-
-// socketMount is a tcp/unix socket that listens for a Cloud SQL instance.
-type socketMount struct {
+// socket is a TCP or UNIX domain socket that proxies traffic to a remove Cloud
+// SQL instance.
+type socket struct {
 	inst     string
 	dialOpts []cloudsqlconn.DialOption
 	listener net.Listener
 }
 
-func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst InstanceConnConfig, version string) (*socketMount, error) {
+// newSocket initializes the socket based on the provided configure and
+// instance-level overrides.
+func newSocket(ctx context.Context, c *Config, pc *portConfig, inst InstanceConnConfig, version string) (*socket, error) {
 	var (
 		// network is one of "tcp" or "unix"
 		network string
@@ -498,11 +521,11 @@ func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst Inst
 	//   instance)
 	// use a TCP listener.
 	// Otherwise, use a Unix socket.
-	if (conf.UnixSocket == "" && inst.UnixSocket == "") ||
+	if (c.UnixSocket == "" && inst.UnixSocket == "") ||
 		(inst.Addr != "" || inst.Port != 0) {
 		network = "tcp"
 
-		a := conf.Addr
+		a := c.Addr
 		if inst.Addr != "" {
 			a = inst.Addr
 		}
@@ -511,7 +534,7 @@ func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst Inst
 		switch {
 		case inst.Port != 0:
 			np = inst.Port
-		case conf.Port != 0:
+		case c.Port != 0:
 			np = pc.nextPort()
 		default:
 			np = pc.nextDBPort(version)
@@ -521,7 +544,7 @@ func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst Inst
 	} else {
 		network = "unix"
 
-		dir := conf.UnixSocket
+		dir := c.UnixSocket
 		if dir == "" {
 			dir = inst.UnixSocket
 		}
@@ -548,87 +571,7 @@ func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst Inst
 	if err != nil {
 		return nil, err
 	}
-	opts := conf.DialOptions(inst)
-	m := &socketMount{inst: inst.Name, dialOpts: opts, listener: ln}
+	opts := c.DialOptions(inst)
+	m := &socket{inst: inst.Name, dialOpts: opts, listener: ln}
 	return m, nil
-}
-
-func (s *socketMount) Addr() net.Addr {
-	return s.listener.Addr()
-}
-
-func (s *socketMount) Accept() (net.Conn, error) {
-	return s.listener.Accept()
-}
-
-// close stops the mount from listening for any more connections
-func (s *socketMount) Close() error {
-	return s.listener.Close()
-}
-
-// proxyConn sets up a bidirectional copy between two open connections
-func (c *Client) proxyConn(inst string, client, server net.Conn) {
-	// only allow the first side to give an error for terminating a connection
-	var o sync.Once
-	cleanup := func(errDesc string, isErr bool) {
-		o.Do(func() {
-			client.Close()
-			server.Close()
-			if isErr {
-				c.logger.Errorf(errDesc)
-			} else {
-				c.logger.Infof(errDesc)
-			}
-		})
-	}
-
-	// copy bytes from client to server
-	go func() {
-		buf := make([]byte, 8*1024) // 8kb
-		for {
-			n, cErr := client.Read(buf)
-			var sErr error
-			if n > 0 {
-				_, sErr = server.Write(buf[:n])
-			}
-			switch {
-			case cErr == io.EOF:
-				cleanup(fmt.Sprintf("[%s] client closed the connection", inst), false)
-				return
-			case cErr != nil:
-				cleanup(fmt.Sprintf("[%s] connection aborted - error reading from client: %v", inst, cErr), true)
-				return
-			case sErr == io.EOF:
-				cleanup(fmt.Sprintf("[%s] instance closed the connection", inst), false)
-				return
-			case sErr != nil:
-				cleanup(fmt.Sprintf("[%s] connection aborted - error writing to instance: %v", inst, cErr), true)
-				return
-			}
-		}
-	}()
-
-	// copy bytes from server to client
-	buf := make([]byte, 8*1024) // 8kb
-	for {
-		n, sErr := server.Read(buf)
-		var cErr error
-		if n > 0 {
-			_, cErr = client.Write(buf[:n])
-		}
-		switch {
-		case sErr == io.EOF:
-			cleanup(fmt.Sprintf("[%s] instance closed the connection", inst), false)
-			return
-		case sErr != nil:
-			cleanup(fmt.Sprintf("[%s] connection aborted - error reading from instance: %v", inst, sErr), true)
-			return
-		case cErr == io.EOF:
-			cleanup(fmt.Sprintf("[%s] client closed the connection", inst), false)
-			return
-		case cErr != nil:
-			cleanup(fmt.Sprintf("[%s] connection aborted - error writing to client: %v", inst, sErr), true)
-			return
-		}
-	}
 }


### PR DESCRIPTION
This commit refactors (with no behavior changes, by definition) the
internals of internal/proxy/proxy.go.

This commit extracts all socket proxy concerns into a ProxyServer
interface in preparation for adding support for a FUSE-based
ProxyServer. In addition, this commit makes the following re-names:

- socketMount -> socket: represents a TCP or Unix domain socket
  connected to a Cloud SQL instance
- Client -> Session: represents a single invocation of the Proxy with
  the provided configuration.

Finally, this commit extracts the common behavior of counting
connections into a Counter that may be shared across ProxyServer
instances. The commit also pulls out the shared code that proxies local
connections to a remote Cloud SQL instance.