### PR TITLE
feat: add initial support for FUSE

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -216,6 +216,14 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 		return newBadCommandError("missing instance_connection_name (e.g., project:region:instance)")
 	}
 
+	if conf.FUSE != "" {
+		if err := proxy.SupportsFUSE(); err != nil {
+			return newBadCommandError(
+				fmt.Sprintf("--fuse is not supported: %v", err),
+			)
+		}
+	}
+
 	if len(args) == 0 && conf.FUSE == "" && conf.FUSETempDir != "" {
 		return newBadCommandError("cannot specify --fuse-tmp-dir without --fuse")
 	}

--- a/cmd/root_windows_test.go
+++ b/cmd/root_windows_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestWindowsDoesNotSupportFUSE(t *testing.T) {
+	c := NewCommand()
+	// Keep the test output quiet
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	// Disable execute behavior
+	c.RunE = func(*cobra.Command, []string) error { return nil }
+	c.SetArgs([]string{"--fuse"})
+
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("want error != nil, got = nil")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.12.2
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.8
+	github.com/hanwen/go-fuse v1.0.0
 	github.com/hanwen/go-fuse/v2 v2.1.0
 	github.com/jackc/pgx/v4 v4.16.1
 	github.com/lib/pq v1.10.6

--- a/go.sum
+++ b/go.sum
@@ -649,6 +649,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
+github.com/hanwen/go-fuse v1.0.0 h1:GxS9Zrn6c35/BnfiVsZVWmsG803xwE7eVRDvcf/BEVc=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/hanwen/go-fuse/v2 v2.1.0 h1:+32ffteETaLYClUj0a3aHjZ1hOPxxaNEHiZiujuDaek=
 github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO00GgRLGryc=

--- a/internal/proxy/fuse.go
+++ b/internal/proxy/fuse.go
@@ -1,0 +1,73 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"syscall"
+
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/v2/fs"
+)
+
+// readme represents a static read-only text file.
+type readme struct {
+	fs.Inode
+}
+
+const readmeText = `
+When programs attempt to open files in this directory, a remote connection to
+the Cloud SQL instance of the same name will be established.
+
+That is, running:
+
+	mysql -u root -S "/path/to/this/directory/project:region:instance-2"
+	-or-
+	psql "host=/path/to/this/directory/project:region:instance-2 dbname=mydb user=myuser"
+
+will open a new connection to the specified instance, given you have the correct
+permissions.
+
+Listing the contents of this directory will show all instances with active
+connections.
+`
+
+// Getattr implements fs.NodeGetattrer and indicates that this file is a regular
+// file.
+func (*readme) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	*out = fuse.AttrOut{Attr: fuse.Attr{
+		Mode: 0444 | syscall.S_IFREG,
+		Size: uint64(len(readmeText)),
+	}}
+	return fs.OK
+}
+
+// Read implements fs.NodeReader and supports incremental reads.
+func (*readme) Read(ctx context.Context, f fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	end := int(off) + len(dest)
+	if end > len(readmeText) {
+		end = len(readmeText)
+	}
+	return fuse.ReadResultData([]byte(readmeText[off:end])), fs.OK
+}
+
+// Open implements fs.NodeOpener and supports opening the README as a read-only
+// file.
+func (*readme) Open(ctx context.Context, mode uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	df := nodefs.NewDataFile([]byte(readmeText))
+	rf := nodefs.NewReadOnlyFile(df)
+	return rf, 0, fs.OK
+}

--- a/internal/proxy/fuse_darwin.go
+++ b/internal/proxy/fuse_darwin.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"os"
+)
+
+const (
+	macfusePath = "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse"
+	osxfusePath = "/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse"
+)
+
+// SupportsFUSE checks if macfuse or osxfuse are installed on the host by
+// looking for both in their known installation location.
+func SupportsFUSE() error {
+	// This code follows the same strategy as hanwen/go-fuse.
+	// See https://github.com/hanwen/go-fuse/blob/0f728ba15b38579efefc3dc47821882ca18ffea7/fuse/mount_darwin.go#L121-L124.
+
+	// check for macfuse first (newer version of osxfuse)
+	if _, err := os.Stat(macfusePath); err != nil {
+		// if that fails, check for osxfuse next
+		if _, err := os.Stat(osxfusePath); err != nil {
+			return errors.New("failed to find osxfuse or macfuse: verify FUSE installation and try again (see https://osxfuse.github.io).")
+		}
+	}
+	return nil
+}

--- a/internal/proxy/fuse_linux.go
+++ b/internal/proxy/fuse_linux.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// SupportsFUSE checks if the fusermount binary is present in the PATH or a well
+// known location.
+func SupportsFUSE() error {
+	// This code follows the same strategy found in hanwen/go-fuse.
+	// See https://github.com/hanwen/go-fuse/blob/0f728ba15b38579efefc3dc47821882ca18ffea7/fuse/mount_linux.go#L184-L198.
+	if _, err := exec.LookPath("fusermount"); err != nil {
+		if _, err := exec.LookPath("/bin/fusermount"); err != nil {
+			return errors.New("fusermount binary not found in PATH or /bin")
+		}
+	}
+	return nil
+}

--- a/internal/proxy/fuse_linux_test.go
+++ b/internal/proxy/fuse_linux_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/proxy"
+)
+
+func TestFUSESupport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fuse tests in short mode.")
+	}
+
+	removePath := func() func() {
+		original := os.Getenv("PATH")
+		os.Unsetenv("PATH")
+		return func() { os.Setenv("PATH", original) }
+	}
+	if err := proxy.SupportsFUSE(); err != nil {
+		t.Fatalf("expected FUSE to be support (PATH set): %v", err)
+	}
+	cleanup := removePath()
+	defer cleanup()
+
+	if err := proxy.SupportsFUSE(); err != nil {
+		t.Fatalf("expected FUSE to be supported (PATH unset): %v", err)
+	}
+}

--- a/internal/proxy/fuse_test.go
+++ b/internal/proxy/fuse_test.go
@@ -1,0 +1,99 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows && !darwin
+// +build !windows,!darwin
+
+package proxy_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/log"
+	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/proxy"
+)
+
+func randTmpDir(t interface {
+	Fatalf(format string, args ...interface{})
+}) string {
+	name, err := ioutil.TempDir("", "*")
+	if err != nil {
+		t.Fatalf("failed to create tmp dir: %v", err)
+	}
+	return name
+}
+
+// tryFunc executes the provided function up to maxCount times, sleeping 100ms
+// between attempts.
+func tryFunc(f func() error, maxCount int) error {
+	var errCount int
+	for {
+		err := f()
+		if err == nil {
+			return nil
+		}
+		errCount++
+		if errCount == maxCount {
+			return err
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func TestREADME(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fuse tests in short mode.")
+	}
+	ctx := context.Background()
+
+	dir := randTmpDir(t)
+	conf := &proxy.Config{
+		FUSE:        dir,
+		FUSETempDir: randTmpDir(t),
+	}
+	logger := log.NewStdLogger(os.Stdout, os.Stdout)
+	d := &fakeDialer{}
+	c, err := proxy.NewClient(ctx, d, logger, conf)
+	if err != nil {
+		t.Fatalf("want error = nil, got = %v", err)
+	}
+
+	ready := make(chan struct{})
+	go c.Serve(ctx, func() { close(ready) })
+	select {
+	case <-ready:
+	case <-time.After(time.Minute):
+		t.Fatal("proxy.Client failed to start serving")
+	}
+
+	_, err = ioutil.ReadFile(filepath.Join(dir, "README"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cErr := c.Close(); cErr != nil {
+		t.Fatalf("c.Close(): %v", cErr)
+	}
+
+	// verify that c.Close unmounts the FUSE server
+	_, err = ioutil.ReadFile(filepath.Join(dir, "README"))
+	if err == nil {
+		t.Fatal("expected ioutil.Readfile to fail, but it succeeded")
+	}
+}

--- a/internal/proxy/fuse_windows.go
+++ b/internal/proxy/fuse_windows.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"errors"
+)
+
+// SupportsFUSE is false on Windows.
+func SupportsFUSE() error {
+	return errors.New("fuse is not supported on Windows")
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -23,11 +23,14 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"cloud.google.com/go/cloudsqlconn"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/cloudsql"
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/v2/internal/gcloud"
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
 	"golang.org/x/oauth2"
 )
 
@@ -82,6 +85,15 @@ type Config struct {
 	// UnixSocket is the directory where Unix sockets will be created,
 	// connected to any Instances. If set, takes precedence over Addr and Port.
 	UnixSocket string
+
+	// FUSE enables a file system in user space at the provided path that
+	// connects to the requested instance only when a client requests it.
+	FUSE string
+
+	// FUSETempDir sets the temporary directory where the FUSE mount will place
+	// Unix domain sockets connected to Cloud SQL instances. The temp directory
+	// is not accessed directly.
+	FUSETempDir string
 
 	// IAMAuthN enables automatic IAM DB Authentication for all instances.
 	// Postgres-only.
@@ -243,9 +255,15 @@ type Client struct {
 	waitOnClose time.Duration
 
 	logger cloudsql.Logger
+
+	fuseServer *fuse.Server
+
+	// Inode adds support for FUSE operations.
+	fs.Inode
 }
 
-// NewClient completes the initial setup required to get the proxy to a "steady" state.
+// NewClient completes the initial setup required to get the proxy to a "steady"
+// state.
 func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *Config) (*Client, error) {
 	// Check if the caller has configured a dialer.
 	// Otherwise, initialize a new one.
@@ -258,6 +276,25 @@ func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *
 		if err != nil {
 			return nil, fmt.Errorf("error initializing dialer: %v", err)
 		}
+	}
+
+	c := &Client{
+		logger:      l,
+		dialer:      d,
+		maxConns:    conf.MaxConnections,
+		waitOnClose: conf.WaitOnClose,
+	}
+
+	if conf.FUSE != "" {
+		srv, err := fs.Mount(conf.FUSE, c, &fs.Options{
+			MountOptions: fuse.MountOptions{AllowOther: true},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("FUSE mount failed: %q: %v", conf.FUSE, err)
+		}
+		c.fuseServer = srv
+
+		return c, nil
 	}
 
 	for _, inst := range conf.Instances {
@@ -287,14 +324,20 @@ func NewClient(ctx context.Context, d cloudsql.Dialer, l cloudsql.Logger, conf *
 		l.Infof("[%s] Listening on %s", inst.Name, m.Addr())
 		mnts = append(mnts, m)
 	}
-	c := &Client{
-		mnts:        mnts,
-		logger:      l,
-		dialer:      d,
-		maxConns:    conf.MaxConnections,
-		waitOnClose: conf.WaitOnClose,
-	}
+	c.mnts = mnts
 	return c, nil
+}
+
+// Lookup implements the fs.NodeLookuper interface and returns an index node
+// (inode) for a symlink that points to a Unix domain socket. The Unix domain
+// socket is connected to the requested Cloud SQL instance. Lookup returns a
+// symlink (instead of the socket itself) so that multiple callers all use the
+// same Unix socket.
+func (c *Client) Lookup(ctx context.Context, instance string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	if instance == "README" {
+		return c.NewInode(ctx, &readme{}, fs.StableAttr{}), fs.OK
+	}
+	return nil, syscall.ENOENT
 }
 
 // CheckConnections dials each registered instance and reports any errors that
@@ -388,6 +431,11 @@ func (m MultiErr) Error() string {
 // Close triggers the proxyClient to shutdown.
 func (c *Client) Close() error {
 	var mErr MultiErr
+	if c.fuseServer != nil {
+		if err := c.fuseServer.Unmount(); err != nil {
+			mErr = append(mErr, err)
+		}
+	}
 	// First, close all open socket listeners to prevent additional connections.
 	for _, m := range c.mnts {
 		err := m.Close()


### PR DESCRIPTION
This PR adds:
- CLI flags for fuse and fuse-temp-dir
- A check if the OS supports FUSE
- a FUSE server that serves a README
- Support for closing the FUSE server

The next PR(s) will include:
- returning a symlink to a Unix domain socket that is connected to the Cloud SQL instance
- (maybe) support for "warming up" instance connection names in FUSE mode